### PR TITLE
Went to fix up the exists in LDRURL, did that and also got side tracked

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,4 +73,5 @@ setup(
                         'pyxdg',
                         'pypremis',
                         'controlledvocab',
-                        'hierarchicalrecord'])
+                        'hierarchicalrecord',
+                        'requests'])

--- a/uchicagoldrtoolsuite/lib/structuring/abc/ldritem.py
+++ b/uchicagoldrtoolsuite/lib/structuring/abc/ldritem.py
@@ -7,55 +7,44 @@ Created on Apr 13, 2016
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 class LDRItem(metaclass=ABCMeta):
-    
+
     @abstractmethod
     def read(self):
         pass
-    
+
     @abstractmethod
     def write(self):
         pass
-    
+
     @abstractmethod
     def open(self):
         pass
-    
+
     @abstractmethod
     def close(self):
         pass
-    
-    @abstractmethod
-    def is_flo(self):
-        pass
-    
+
     @abstractmethod
     def exists(self):
         pass
-    
-    def getname(self):
+
+    def get_name(self):
         return self._item_name
-    
-    def setname(self, value):
+
+    def set_name(self, value):
         if isinstance(value, str):
             self._item_name = value
         else:
             raise ValueError("item_name must be a string")
-        
-    def getisflo(self):
-        return self._is_flo
-    
-    def setisflo(self, value):
+
+    def get_is_flo(self):
+        return self.is_flo
+
+    def set_is_flo(self, value):
         if isinstance(value, bool):
-            self._is_flo = True
+            self._is_flo = value
         else:
             raise ValueError("is_flo must be either True or False")
 
-    def getpipe(self):
-        return self._pipe
-    
-    def setpipe(self, value):
-        self._pipe = value
-
-    item_name = abstractproperty(getname, setname)
-    pipe = abstractproperty(getpipe, setpipe)
-    is_flo = abstractproperty(getisflo, setisflo)
+    item_name = property(get_name, set_name)
+    is_flo = property(get_is_flo, set_is_flo)

--- a/uchicagoldrtoolsuite/lib/structuring/abc/ldritem.py
+++ b/uchicagoldrtoolsuite/lib/structuring/abc/ldritem.py
@@ -1,13 +1,12 @@
 '''
 Created on Apr 13, 2016
 
-@author: tdanstrom
+@author: tdanstrom, balsamo
 '''
 
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 class LDRItem(metaclass=ABCMeta):
-
     @abstractmethod
     def read(self):
         pass
@@ -27,6 +26,12 @@ class LDRItem(metaclass=ABCMeta):
     @abstractmethod
     def exists(self):
         pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
 
     def get_name(self):
         return self._item_name

--- a/uchicagoldrtoolsuite/lib/structuring/ldrpathregularfile.py
+++ b/uchicagoldrtoolsuite/lib/structuring/ldrpathregularfile.py
@@ -1,39 +1,51 @@
-
-from os.path import abspath, exists
 from pathlib import Path
+from .abc.ldritem import LDRItem
 
 
-class LDRPathRegularFile(object):
+class LDRPathRegularFile(LDRItem):
     def __init__(self, param1):
 
         self.item_name = param1
         self.path = Path(self.item_name)
         self.pipe = None
         self.is_flo = True
-        
-    def read(self, blocksize=1024):
-        with self.path.open('rb'):
-            bytes_data = self.path.read_bytes(blocksize)
-            while len(bytes_data) > 0:
-                yield bytes_data
-                bytes_data = self.path.read_bytes(blocksize)
 
-    def open(self):
-        return self.path.open('ab')
-        
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+    def read(self, blocksize=1024):
+        if not self.pipe:
+            raise OSError('{} not open for reading'.format(str(self.path)))
+        return self.pipe.read(blocksize)
+
+    def open(self, mode='rb', buffering=-1, errors=None):
+        if "t" in mode:
+            raise OSError('LDR Items do not support text mode')
+        if mode == 'r' or \
+                mode == 'w' or \
+                mode == 'a':
+            mode = mode + "b"
+        self.pipe = open(str(self.path), mode=mode,
+                         buffering=buffering, errors=errors)
+        return self
+
     def close(self):
         if not self.pipe:
             raise ValueError("file {} is already closed".format(self.item_name))
         else:
             self.pipe.close()
             self.pipe = None
-        
+
     def exists(self):
-        return exists(abspath(self.name))
-    
+        return self.path.exists()
+
     def write(self, data):
         if self.pipe:
             self.pipe.write(data)
             return True
         else:
-            raise ValueError("file {} is not opened and therefore cannot write".format(self.item_name))
+            raise ValueError("file {} is not opened and " +
+                             "therefore cannot write".format(self.item_name))

--- a/uchicagoldrtoolsuite/lib/structuring/ldrpathregularfile.py
+++ b/uchicagoldrtoolsuite/lib/structuring/ldrpathregularfile.py
@@ -4,17 +4,10 @@ from .abc.ldritem import LDRItem
 
 class LDRPathRegularFile(LDRItem):
     def __init__(self, param1):
-
         self.item_name = param1
         self.path = Path(self.item_name)
         self.pipe = None
         self.is_flo = True
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.close()
 
     def read(self, blocksize=1024):
         if not self.pipe:

--- a/uchicagoldrtoolsuite/lib/structuring/ldrurl.py
+++ b/uchicagoldrtoolsuite/lib/structuring/ldrurl.py
@@ -14,20 +14,13 @@ class LDRURL(LDRItem):
         self.tmpdir = None
         self.is_flo = True
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.close()
-
-    def is_flo(self):
-        # True
-        return self.is_flo
-
     def read(self, blocksize=1024):
         if not self.pipe:
             raise OSError('{} not open for reading'.format(str(self.item_name)))
         return self.pipe.read(blocksize)
+
+    def write(self, data):
+        raise OSError('URLs are read only.')
 
     def open(self, mode='rb', buffering=-1, errors=None):
         if "t" in mode:
@@ -63,5 +56,3 @@ class LDRURL(LDRItem):
         r = rhead(self.item_name)
         return r.status_code == codes.ok
 
-    def write(self, data):
-        raise OSError('URLs are read only.')

--- a/uchicagoldrtoolsuite/lib/structuring/ldrurl.py
+++ b/uchicagoldrtoolsuite/lib/structuring/ldrurl.py
@@ -20,9 +20,13 @@ class LDRURL(LDRItem):
     def __exit__(self, type, value, traceback):
         self.close()
 
+    def is_flo(self):
+        # True
+        return self.is_flo
+
     def read(self, blocksize=1024):
         if not self.pipe:
-            raise OSError('{} not open for reading'.format(str(self.path)))
+            raise OSError('{} not open for reading'.format(str(self.item_name)))
         return self.pipe.read(blocksize)
 
     def open(self, mode='rb', buffering=-1, errors=None):
@@ -56,7 +60,7 @@ class LDRURL(LDRItem):
                 self.tmpdir = None
 
     def exists(self):
-        r = rget(self.item_name)
+        r = rhead(self.item_name)
         return r.status_code == codes.ok
 
     def write(self, data):


### PR DESCRIPTION
 fixing up the inheritance in ldrurl and ldrpathregularfile. According to the docs abstractproperty is depreciated and property handles the same use case now, so I swapped that out in the abc and also removed references to pipe as per earlier discussion.

Added requests as a requirement in the setup.py

citation for abstractproperty: https://docs.python.org/3/library/abc.html#abc.abstractclassmethod
