### PR TITLE
Making python-magic an optional dependency in the premis creator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,24 @@
 from setuptools import setup
 from setuptools import find_packages
 
+
 def readme():
     with open('README.md', 'r') as f:
         return f.read()
 
 setup(
     name = 'uchicagoldrtoolsuite',
+    description = "A suite of tools for working with digital repositories",
+    long_description = readme(),
     version = '0.0.1dev',
     author = "Brian Balsamo, Tyler Danstrom",
     author_email = "balsamo@uchicago.edu, tdanstrom@uchicago.edu",
+    keywords = [
+        "uchicago",
+        "repository",
+        "file-level",
+        "processing"
+    ],
     packages = find_packages(
         exclude = [
             "build",
@@ -23,8 +32,6 @@ setup(
             "uchicagoldr.egg-info"
         ]
     ),
-    description = "A suite of tools for working with digital repositories",
-    long_description=readme(),
     entry_points = {
         'console_scripts':[
             'ldrstage = uchicagoldrtoolsuite.apps.stager:launch',
@@ -36,7 +43,6 @@ setup(
             'ldrpostinstall = uchicagoldrtoolsuite.apps.postinstall:launch'
         ]
     },
-    keywords = ["uchicago","repository","file-level","processing"],
     package_data = {
         '': ["*.md"]
     },
@@ -49,7 +55,7 @@ setup(
             'controlledvocabs/filepaths_presform.json',
             'controlledvocabs/restriction_codes.json'
         ]),
-        ('record_configs',[
+        ('record_configs', [
             'record_configs/AccessionRecordFields.csv'
         ])
     ],
@@ -59,7 +65,7 @@ setup(
         "Intended Audience :: Developers",
         "Operating System :: Unix",
         "Topic :: Software Development :: Libraries :: Python Modules",
-        ],
+    ],
     dependency_links = [
         'https://github.com/uchicago-library/uchicagoldr-premiswork' +
         '/tarball/master#egg=pypremis',
@@ -68,9 +74,14 @@ setup(
         'https://github.com/uchicago-library/uchicagoldr-hierarchicalrecords' +
         '/tarball/master#egg=hierarchicalrecord',
     ],
-    install_requires = ['treelib',
-                        'python-magic',
-                        'pyxdg',
-                        'pypremis',
-                        'controlledvocab',
-                        'hierarchicalrecord'])
+    install_requires = [
+        'treelib',
+        'pyxdg',
+        'pypremis',
+        'controlledvocab',
+        'hierarchicalrecord'
+    ],
+    extras_require = {
+        'magic_mimes': ["python-magic"]
+    }
+)

--- a/uchicagoldrtoolsuite/lib/premisobjectrecordcreator.py
+++ b/uchicagoldrtoolsuite/lib/premisobjectrecordcreator.py
@@ -1,11 +1,14 @@
 from os.path import getsize, split
-from magic import from_file
 from mimetypes import guess_type
 from uuid import uuid1
 from pypremis.lib import PremisRecord
 from pypremis.nodes import *
 from .convenience import sane_hash
 
+try:
+    from magic import from_file
+except:
+    pass
 
 class PremisObjectRecordCreator(object):
     """


### PR DESCRIPTION
Wrapped the import in a try - the current use of the imported method is try wrapped already - so everything should behave correctly even if the package can't be imported.

Reorganized the setup.py file a bit and added the extras_require dictionary so that python-magic can be specified as an optional dependency.
