### PR TITLE
Utils Paths --> conf, techmd creator touchup, logging size --> conf

### DIFF
--- a/uchicagoldrtoolsuite/bit_level/app/accessionrecordadder.py
+++ b/uchicagoldrtoolsuite/bit_level/app/accessionrecordadder.py
@@ -123,6 +123,7 @@ class AccessionRecordAdder(CLIApp):
         else:
             raise AssertionError('Either file or text should be selected')
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/adminnoteadder.py
+++ b/uchicagoldrtoolsuite/bit_level/app/adminnoteadder.py
@@ -124,6 +124,7 @@ class AdminNoteAdder(CLIApp):
         else:
             raise AssertionError('Either file or text should be selected')
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/legalnoteadder.py
+++ b/uchicagoldrtoolsuite/bit_level/app/legalnoteadder.py
@@ -124,6 +124,7 @@ class LegalNoteAdder(CLIApp):
         else:
             raise AssertionError('Either file or text should be selected')
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/premiscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/app/premiscreator.py
@@ -54,7 +54,7 @@ class PremisCreator(CLIApp):
         # Add application specific flags/arguments
         self.parser.add_argument("stage_id", help="The stage identifier",
                                  type=str, action='store')
-        self.parser.add_argument("--skip-existing", help="Skip material " +
+        self.parser.add_argument("--skip_existing", help="Skip material " +
                                  "suites which already claim to have " +
                                  "premis records",
                                  action='store_true',

--- a/uchicagoldrtoolsuite/bit_level/app/premiscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/app/premiscreator.py
@@ -94,6 +94,7 @@ class PremisCreator(CLIApp):
         premis_creator = GenericPREMISCreator(stage)
         premis_creator.process(skip_existing=args.skip_existing)
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/premisrestrictionsetter.py
+++ b/uchicagoldrtoolsuite/bit_level/app/premisrestrictionsetter.py
@@ -113,6 +113,7 @@ class PremisRestrictionSetter(CLIApp):
         )
         premis_restriction_setter.process()
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/premisrestrictionsetter.py
+++ b/uchicagoldrtoolsuite/bit_level/app/premisrestrictionsetter.py
@@ -60,10 +60,10 @@ class PremisRestrictionSetter(CLIApp):
         self.parser.add_argument("--reason", help="The reason for setting " +
                                  "this restriction",
                                  action="append")
-        self.parser.add_argument("--donor-stipulation", help="A donor " +
+        self.parser.add_argument("--donor_stipulation", help="A donor " +
                                  "stipulation pertaining to this restriction.",
                                  action="append")
-        self.parser.add_argument("--linking-agentid", help="Any linking " +
+        self.parser.add_argument("--linking_agentid", help="Any linking " +
                                  "agent identifiers pertaining to this " +
                                  "restriction.",
                                  action="append")

--- a/uchicagoldrtoolsuite/bit_level/app/presformcreator.py
+++ b/uchicagoldrtoolsuite/bit_level/app/presformcreator.py
@@ -173,6 +173,7 @@ class PresformCreator(CLIApp):
         presform_creator.process(skip_existing=args.skip_existing,
                                  data_transfer_obj=dto)
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/presformcreator.py
+++ b/uchicagoldrtoolsuite/bit_level/app/presformcreator.py
@@ -57,32 +57,32 @@ class PresformCreator(CLIApp):
         # Add application specific flags/arguments
         self.parser.add_argument("stage_id", help="The id of the stage",
                                  type=str, action='store')
-        self.parser.add_argument("--skip-existing", help="Skip material " +
+        self.parser.add_argument("--skip_existing", help="Skip material " +
                                  "suites which already claim to have " +
                                  "at least one presform",
                                  action='store_true',
                                  default=False)
-        self.parser.add_argument("--disable-office2pdf",
+        self.parser.add_argument("--disable_office2pdf",
                                  help="Disable the OfficeToPDFConverter",
                                  action='store_true',
                                  default=False)
-        self.parser.add_argument("--disable-office2csv",
+        self.parser.add_argument("--disable_office2csv",
                                  help="Disable the OfficeToCSVConverter",
                                  action='store_true',
                                  default=False)
-        self.parser.add_argument("--disable-office2txt",
+        self.parser.add_argument("--disable_office2txt",
                                  help="Disable the OfficeToTXTConverter",
                                  action='store_true',
                                  default=False)
-        self.parser.add_argument("--disable-videoconverter",
+        self.parser.add_argument("--disable_videoconverter",
                                  help="Disable the VideoConverter",
                                  action='store_true',
                                  default=False)
-        self.parser.add_argument("--disable-imageconverter",
+        self.parser.add_argument("--disable_imageconverter",
                                  help="Disable the ImageConverter",
                                  action='store_true',
                                  default=False)
-        self.parser.add_argument("--disable-audioconverter",
+        self.parser.add_argument("--disable_audioconverter",
                                  help="Disable the AudioConverter",
                                  action='store_true',
                                  default=False)

--- a/uchicagoldrtoolsuite/bit_level/app/stager.py
+++ b/uchicagoldrtoolsuite/bit_level/app/stager.py
@@ -62,10 +62,9 @@ class Stager(CLIApp):
         self.parser.add_argument("prefix", help="The prefix defining the " +
                                  "type of run that is being processed",
                                  type=str, action='store')
-        self.parser.add_argument("--destination-root", help="The location " +
-                                 "that the staging directory should be " +
-                                 "created in",
-                                 type=str, action='store',
+        self.parser.add_argument("--staging_env", help="The path to your " +
+                                 "staging environment",
+                                 type=str,
                                  default=None)
         self.parser.add_argument("--resume", "-r", help="An integer for a " +
                                  "run that needs to be resumed.",
@@ -94,8 +93,8 @@ class Stager(CLIApp):
         self.set_conf(conf_dir=args.conf_dir, conf_filename=args.conf_file)
 
         # App code
-        if args.destination_root:
-            destination_root = args.destination_root
+        if args.staging_env:
+            destination_root = args.staging_env
         else:
             destination_root = self.conf.get("Paths",
                                              "staging_environment_path")

--- a/uchicagoldrtoolsuite/bit_level/app/stager.py
+++ b/uchicagoldrtoolsuite/bit_level/app/stager.py
@@ -141,6 +141,7 @@ class Stager(CLIApp):
 
         seg = ext_seg_packager.package()
         stage.add_segment(seg)
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, destination_root, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/stager.py
+++ b/uchicagoldrtoolsuite/bit_level/app/stager.py
@@ -73,7 +73,7 @@ class Stager(CLIApp):
                                  "directory that needs to be staged.",
                                  type=str, action='store',
                                  default=None)
-        self.parser.add_argument("--filter-pattern", help="A regex to " +
+        self.parser.add_argument("--filter_pattern", help="A regex to " +
                                  "use to exclude files whose paths match.",
                                  type=str, action='store',
                                  default=None)

--- a/uchicagoldrtoolsuite/bit_level/app/technicalmetadatacreator.py
+++ b/uchicagoldrtoolsuite/bit_level/app/technicalmetadatacreator.py
@@ -134,6 +134,7 @@ class TechnicalMetadataCreator(CLIApp):
         techmd_creator.process(skip_existing=args.skip_existing,
                                data_transfer_obj=dto)
 
+        log.info("Writing...")
         writer = FileSystemStageWriter(stage, staging_env, eq_detect=args.eq_detect)
         writer.write()
         log.info("Complete")

--- a/uchicagoldrtoolsuite/bit_level/app/technicalmetadatacreator.py
+++ b/uchicagoldrtoolsuite/bit_level/app/technicalmetadatacreator.py
@@ -57,7 +57,7 @@ class TechnicalMetadataCreator(CLIApp):
         # Add application specific flags/arguments
         self.parser.add_argument("stage_id", help="The id of the stage",
                                  type=str, action='store')
-        self.parser.add_argument("--skip-existing", help="Skip material " +
+        self.parser.add_argument("--skip_existing", help="Skip material " +
                                  "suites which already claim to have " +
                                  "technical metadata",
                                  action='store_true',

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/audioconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/audioconverter.py
@@ -32,9 +32,6 @@ class AudioConverter(Converter):
     A class for converting a variety of audio files to FLAC
     """
 
-    # Set the libreoffice path we'll be using in the bash command wrapper
-    ffmpeg_path = 'ffmpeg'
-
     # Explicitly claimed mimes this converter should be able to handle
     _claimed_mimes = [
         'audio/x-aiff',
@@ -69,7 +66,7 @@ class AudioConverter(Converter):
     _claimed_mimes = list(set(_claimed_mimes))
 
     def __init__(self, input_materialsuite, working_dir,
-                 timeout=None):
+                 timeout=None, data_transfer_obj={}):
         """
         Instantiate a converter
 
@@ -87,6 +84,10 @@ class AudioConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.ffmpeg_path = data_transfer_obj.get('ffmpeg_path', None)
+        if self.ffmpeg_path is None:
+            raise ValueError('No ffmpeg_path specified in the data ' +
+                             'transfer object!')
         log.debug("AudioConverter spawned: {}".format(str(self)))
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/imageconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/imageconverter.py
@@ -32,9 +32,6 @@ class ImageConverter(Converter):
     A class for converting a variety of image file types to TIF
     """
 
-    # Set the libreoffice path we'll be using in the bash command wrapper
-    ffmpeg_path = 'ffmpeg'
-
     # Explicitly claimed mimes this converter should be able to handle
     _claimed_mimes = [
         "image/jpeg",
@@ -68,7 +65,7 @@ class ImageConverter(Converter):
     _claimed_mimes = list(set(_claimed_mimes))
 
     def __init__(self, input_materialsuite, working_dir,
-                 timeout=None):
+                 timeout=None, data_transfer_obj={}):
         """
         Instantiate a converter
 
@@ -86,6 +83,10 @@ class ImageConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.ffmpeg_path = data_transfer_obj.get('ffmpeg_path', None)
+        if self.ffmpeg_path is None:
+            raise ValueError('No ffmpeg_path specified in the data ' +
+                             'transfer object!')
         log.debug("ImageConverter spanwed: {}".format(str(self)))
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/officetocsvconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/officetocsvconverter.py
@@ -32,9 +32,6 @@ class OfficeToCSVConverter(Converter):
     A class for converting a variety of "office" file types to CSV
     """
 
-    # Set the libreoffice path we'll be using in the bash command wrapper
-    libre_office_path = "/Applications/LibreOffice.app/Contents/MacOS/soffice"
-
     # Explicitly claimed mimes this converter should be able to handle
     _claimed_mimes = [
         'application/vnd.ms-excel',
@@ -61,7 +58,7 @@ class OfficeToCSVConverter(Converter):
     _claimed_mimes = list(set(_claimed_mimes))
 
     def __init__(self, input_materialsuite, working_dir,
-                 timeout=None):
+                 timeout=None, data_transfer_obj={}):
         """
         Instantiate a converter
 
@@ -79,6 +76,10 @@ class OfficeToCSVConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.libre_office_path = data_transfer_obj.get('libre_office_path', None)
+        if self.libre_office_path is None:
+            raise ValueError('No libre_office_path specificed in the data' +
+                             'transfer object!')
         log.debug("OfficeToCSVConverter spawned: {}".format(str(self)))
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/officetopdfconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/officetopdfconverter.py
@@ -37,9 +37,6 @@ class OfficeToPDFConverter(Converter):
     ********************
     """
 
-    # Set the libreoffice path we'll be using in the bash command wrapper
-    libre_office_path = "/Applications/LibreOffice.app/Contents/MacOS/soffice"
-
     # Explicitly claimed mimes this converter should be able to handle
     _claimed_mimes = [
         'text/plain',
@@ -89,7 +86,7 @@ class OfficeToPDFConverter(Converter):
     _claimed_mimes = list(set(_claimed_mimes))
 
     def __init__(self, input_materialsuite, working_dir,
-                 timeout=None):
+                 timeout=None, data_transfer_obj={}):
         """
         Instantiate a converter
 
@@ -107,6 +104,10 @@ class OfficeToPDFConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.libre_office_path = data_transfer_obj.get('libre_office_path', None)
+        if self.libre_office_path is None:
+            raise ValueError('No libre_office_path specificed in the data' +
+                             'transfer object!')
         log.debug("OfficeToPDFConverter spawned: {} ".format(str(self)))
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/officetotxtconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/officetotxtconverter.py
@@ -32,9 +32,6 @@ class OfficeToTXTConverter(Converter):
     A class for converting a variety of "office" file types to TXT
     """
 
-    # Set the libreoffice path we'll be using in the bash command wrapper
-    libre_office_path = "/Applications/LibreOffice.app/Contents/MacOS/soffice"
-
     # Explicitly claimed mimes this converter should be able to handle
     _claimed_mimes = [
         'application/rtf',
@@ -73,7 +70,7 @@ class OfficeToTXTConverter(Converter):
     _claimed_mimes = list(set(_claimed_mimes))
 
     def __init__(self, input_materialsuite, working_dir,
-                 timeout=None):
+                 timeout=None, data_transfer_obj={}):
         """
         Instantiate a converter
 
@@ -91,6 +88,10 @@ class OfficeToTXTConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.libre_office_path = data_transfer_obj.get('libre_office_path', None)
+        if self.libre_office_path is None:
+            raise ValueError('No libre_office_path specificed in the data' +
+                             'transfer object!')
         log.debug("OfficeToTXTConverter spawned: {}".format(str(self)))
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/videoconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/videoconverter.py
@@ -32,9 +32,6 @@ class VideoConverter(Converter):
     A class for converting a variety of video file types to AVI
     """
 
-    # Set the libreoffice path we'll be using in the bash command wrapper
-    ffmpeg_path = 'ffmpeg'
-
     # Explicitly claimed mimes this converter should be able to handle
     _claimed_mimes = [
         "video/quicktime",
@@ -68,7 +65,7 @@ class VideoConverter(Converter):
     _claimed_mimes = list(set(_claimed_mimes))
 
     def __init__(self, input_materialsuite, working_dir,
-                 timeout=None):
+                 timeout=None, data_transfer_obj={}):
         """
         Instantiate a converter
 
@@ -86,6 +83,10 @@ class VideoConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.ffmpeg_path = data_transfer_obj.get('ffmpeg_path', None)
+        if self.ffmpeg_path is None:
+            raise ValueError('No ffmpeg_path specified in the data' +
+                             'transfer object!')
         log.debug("VideoConverter spawned: {}".format(str(self)))
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/processors/genericpresformcreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/processors/genericpresformcreator.py
@@ -55,7 +55,8 @@ class GenericPresformCreator(object):
         }
         return "<GenericPresformCreator {}>".format(dumps(attr_dict, sort_keys=True))
 
-    def process(self, skip_existing=False, presform_presforms=False):
+    def process(self, skip_existing=False, presform_presforms=False,
+                data_transfer_obj={}):
         for segment in self.stage.segment_list:
             for materialsuite in segment.materialsuite_list:
                 if not isinstance(materialsuite.get_premis(), LDRItem):
@@ -68,13 +69,15 @@ class GenericPresformCreator(object):
                             continue
                     except:
                         pass
-                self.instantiate_and_make_presforms(materialsuite)
+                self.instantiate_and_make_presforms(materialsuite,
+                                                    data_transfer_obj=data_transfer_obj)
                 if presform_presforms:
                     if materialsuite.presform_list is not None:
                         for presform_ms in materialsuite.presform_list:
-                            self.instantiate_and_make_presforms(presform_ms)
+                            self.instantiate_and_make_presforms(presform_ms,
+                                                                data_transfer_obj=data_transfer_obj)
 
-    def instantiate_and_make_presforms(self, ms):
+    def instantiate_and_make_presforms(self, ms, data_transfer_obj={}):
         """
         write the file to disk an examine it, update its PREMIS
 
@@ -107,5 +110,6 @@ class GenericPresformCreator(object):
                 if x in converter._claimed_mimes:
                     c_working_dir = join(self.working_dir_path, str(uuid1()))
                     makedirs(c_working_dir, exist_ok=True)
-                    c = converter(ms, c_working_dir)
+                    c = converter(ms, c_working_dir,
+                                  data_transfer_obj=data_transfer_obj)
                     c.convert()

--- a/uchicagoldrtoolsuite/bit_level/lib/processors/generictechnicalmetadatacreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/processors/generictechnicalmetadatacreator.py
@@ -49,7 +49,7 @@ class GenericTechnicalMetadataCreator(object):
         }
         return "<GenericTechnicalMetadataCreator {}>".format(dumps(attr_dict, sort_keys=True))
 
-    def process(self, skip_existing=False):
+    def process(self, skip_existing=False, data_transfer_obj={}):
         log.debug("Beginning TECHMD Processing")
         s_num = 0
         for segment in self.stage.segment_list:
@@ -80,7 +80,8 @@ class GenericTechnicalMetadataCreator(object):
                 try:
                     log.debug("No TECHMD detected: Creating")
                     for techmd_creator in self.techmd_creators:
-                        c = techmd_creator(materialsuite, self.working_dir_path)
+                        c = techmd_creator(materialsuite, self.working_dir_path,
+                                           data_transfer_obj=data_transfer_obj)
                         c.process()
                     if materialsuite.presform_list is not None:
                         for presform_ms in materialsuite.presform_list:
@@ -88,7 +89,8 @@ class GenericTechnicalMetadataCreator(object):
                                 raise ValueError("All material suites must have a PREMIS " +
                                                 "record in order to generated technical " +
                                                 "metadata records.")
-                            c = techmd_creator(presform_ms, self.working_dir_path)
+                            c = techmd_creator(presform_ms, self.working_dir_path,
+                                               data_transfer_obj=data_transfer_obj)
                             c.process()
                 except Exception as e:
                     eh.handle(e)

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/apifitscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/apifitscreator.py
@@ -29,11 +29,13 @@ eh = ExceptionHandler()
 
 
 class APIFITsCreator(TechnicalMetadataCreator):
-
-    _API_URL = 'http://127.0.0.1:8080/fits/examine'
-
-    def __init__(self, materialsuite, working_dir, timeout=None):
+    def __init__(self, materialsuite, working_dir, timeout=None,
+                 data_transfer_obj={}):
         super().__init__(materialsuite, working_dir, timeout)
+        self.fits_api_url = data_transfer_obj.get('fits_api_url', None)
+        if self.fits_api_url is None:
+            raise ValueError('No fits_api_url specified in the data ' +
+                             'transfer object!')
         log.debug("APIFITsCreator spawned: {}".format(str(self)))
 
     def __repr__(self):
@@ -41,7 +43,7 @@ class APIFITsCreator(TechnicalMetadataCreator):
             'source_materialsuite': str(self.source_materialsuite),
             'working_dir': str(self.working_dir),
             'timeout': self.timeout,
-            'api_url': self._API_URL
+            'api_url': self.fits_api_url
         }
         return "<APIFITsCreator {}>".format(dumps(attr_dict, sort_keys=True))
 
@@ -89,7 +91,7 @@ class APIFITsCreator(TechnicalMetadataCreator):
         exc = None
         try:
             r = post(
-                self._API_URL,
+                self.fits_api_url,
                 files={'datafile': original_holder.open()}
             )
 

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/fitscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/fitscreator.py
@@ -26,8 +26,13 @@ log = spawn_logger(__name__)
 
 
 class FITsCreator(TechnicalMetadataCreator):
-    def __init__(self, materialsuite, working_dir, timeout=None):
+    def __init__(self, materialsuite, working_dir, timeout=None,
+                 data_transfer_obj={}):
         super().__init__(materialsuite, working_dir, timeout)
+        self.fits_path = data_transfer_obj.get('fits_path', None)
+        if self.fits_path is None:
+            raise ValueError('No fits_path specified in the data ' +
+                             'transfer object!')
         log.debug("FITsCreator spawned: {}".format(str(self)))
 
     def __repr__(self):
@@ -68,7 +73,7 @@ class FITsCreator(TechnicalMetadataCreator):
         ).copy()
 
         fits_file_path = join(self.working_dir, str(uuid1()))
-        cmd = BashCommand(['fits', '-i', content_file_path,
+        cmd = BashCommand([self.fits_path, '-i', content_file_path,
                            '-o', fits_file_path])
 
         if self.get_timeout() is not None:

--- a/uchicagoldrtoolsuite/core/app/abc/cliapp.py
+++ b/uchicagoldrtoolsuite/core/app/abc/cliapp.py
@@ -43,14 +43,14 @@ class CLIApp(App, metaclass=ABCMeta):
 
         # Always allow the user to specify an alternate conf dir
         parser.add_argument(
-            '--conf-dir',
+            '--conf_dir',
             default=None,
             help="Specify a custom configuration directory to be parsed "
             "with precedence over the default and builtin configs."
         )
         # Always allow the user to specify an alternate conf file
         parser.add_argument(
-            '--conf-file',
+            '--conf_file',
             default=None,
             help="Specify a custom configuration filename, if required."
         )

--- a/uchicagoldrtoolsuite/core/lib/masterlog.py
+++ b/uchicagoldrtoolsuite/core/lib/masterlog.py
@@ -55,7 +55,11 @@ def get_log_dir():
     get aggrovated they keep getting dumped there and search through
     the documentation to figure out how to fix that.
     """
-    logdir = conf.get("Logging", "log_dir_path")
+    try:
+        logdir = conf.get("Logging", "log_dir_path")
+    except:
+        master_log.debug("logdir not specified in the config. Setting to ~/ldrtslogs")
+        logdir = None
     if logdir is None:
         logdir = join(expanduser("~"), 'ldrtslogs')
     if not isdir(logdir):
@@ -75,11 +79,17 @@ def activate_master_log_file(verbosity="DEBUG"):
     except:
         master_log.debug("Log size not specified in config. Setting to 1GB")
         max_log_size = 1000000000
+    try:
+        num_backups = conf.getint("Logging", "num_backups")
+    except:
+        masterlog.debug("Number of log backups to store not specified " +
+                        "in config. Setting to 4")
+        num_backups = 4
     logdir = get_log_dir()
     mlog_filepath = join(logdir, master_log_name + ".log")
     h1 = MultiprocessRotatingFileHandler(mlog_filepath,
                                          maxBytes=int(max_log_size/5),
-                                         backupCount=4)
+                                         backupCount=num_backups)
     h1.setLevel(verbosity)
     h1.setFormatter(f)
     master_log.addHandler(h1)


### PR DESCRIPTION
Added a data transfer object that communicates data from either configs or cli flags in application code down into individual techmd creators or converters.

Added an option to set the maximum size of the master log in the config. Default is 1G total space used for logging, 4 backups (as it was previously).

The techmd creator script can now use local fits _or_ a FITsServlet running at some remote address, instead of having to switch that open in the source and recompile, via a CLI flag.

Closes #84
Closes #85
Closes #86
