### PR TITLE
Presform premis overhaul

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
             'ldrprune = uchicagoldrtoolsuite.bit_level.app.pruner:launch',
             'ldrcreatepremis = uchicagoldrtoolsuite.bit_level.app.premiscreator:launch',
             'ldrsetrestriction = uchicagoldrtoolsuite.bit_level.app.premisrestrictionsetter:launch',
-            'ldrarchive = uchicagoldrtoolsuite.bit_levelapp.archiver:launch',
+            'ldrarchive = uchicagoldrtoolsuite.bit_level.app.archiver:launch',
             'ldraru = uchicagoldrtoolsuite.core.app.aru:launch',
             'ldrpostinstall = uchicagoldrtoolsuite.core.app.postinstall:launch',
             'ldraddadminnote = uchicagoldrtoolsuite.bit_level.app.adminnoteadder:launch',
@@ -46,7 +46,7 @@ setup(
             'ldraddaccessionrecord = uchicagoldrtoolsuite.bit_level.app.accessionrecordadder:launch',
             'ldrcreatetechmd = uchicagoldrtoolsuite.bit_level.app.technicalmetadatacreator:launch',
             'ldrcreatepresforms = uchicagoldrtoolsuite.bit_level.app.presformcreator:launch',
-            'ldrmakeagent = uchicagoldrtoolsuite.core.app.premisagentmaker:launch'
+            'ldrmakeagent = uchicagoldrtoolsuite.core.app.premisagentmaker:launch',
         ]
     },
     package_data = {

--- a/uchicagoldrtoolsuite/bit_level/app/archiver.py
+++ b/uchicagoldrtoolsuite/bit_level/app/archiver.py
@@ -66,10 +66,6 @@ class Archiver(CLIApp):
                                  "long term storage environment",
                                  type=str,
                                  default=None)
-        self.parser.add_argument("--live_premis_env", help="The path to your " +
-                                 "live PREMIS environment",
-                                 type=str,
-                                 default=None)
         self.parser.add_argument("--eq_detect", help="The equality " +
                                  "metric to use on writing, check " +
                                  "LDRItemCopier for supported schemes.",
@@ -98,12 +94,6 @@ class Archiver(CLIApp):
             lts_env = self.conf.get("Paths",
                                     "long_term_storage_environment_path")
 
-        if args.live_premis_env:
-            live_premis_env = args.live_premis_env
-        else:
-            live_premis_env = self.conf.get("Paths",
-                                            "live_premis_environment_path")
-
         stage_path = join(staging_env, args.stage_id)
         log.info("Stage Path: {}".format(stage_path))
         log.info("Reading Stage...")
@@ -120,8 +110,7 @@ class Archiver(CLIApp):
             )
         )
         log.info("Writing Archive...")
-        FileSystemArchiveWriter(archive, lts_env, live_premis_env,
-                                args.eq_detect).write()
+        FileSystemArchiveWriter(archive, lts_env, args.eq_detect).write()
         log.info("Complete!")
 
 if __name__ == "__main__":

--- a/uchicagoldrtoolsuite/bit_level/app/archiver.py
+++ b/uchicagoldrtoolsuite/bit_level/app/archiver.py
@@ -1,17 +1,16 @@
-
-from grp import getgrnam
-from os import chmod, chown
-from os.path import join
-from pwd import getpwnam
-from sys import stdout
+from os.path import join, dirname, expanduser, expandvars
 
 from uchicagoldrtoolsuite.core.app.abc.cliapp import CLIApp
-from uchicagoldrtoolsuite.core.lib.idbuilder import IDBuilder
-
-from ..lib.fstools.absolutefilepathtree import AbsoluteFilePathTree
-from ..lib.readers.filesystemstagereader import FileSystemStageReader
+from uchicagoldrtoolsuite.core.lib.masterlog import \
+    spawn_logger, \
+    activate_master_log_file, \
+    activate_job_log_file, \
+    activate_stdout_log
 from ..lib.writers.filesystemarchivewriter import FileSystemArchiveWriter
-from ..lib.transformers.stagetoarchivetransformer import StageToArchiveTransformer
+from ..lib.readers.filesystemstagereader import FileSystemStageReader
+from ..lib.transformers.stagetoarchivetransformer import \
+    StageToArchiveTransformer
+
 
 __author__ = "Brian Balsamo, Tyler Danstrom"
 __email__ = "balsamo@uchicago.edu, tdanstrom@uchicago.edu"
@@ -21,9 +20,14 @@ __publication__ = ""
 __version__ = "0.0.1dev"
 
 
+log = spawn_logger(__name__)
+activate_master_log_file()
+activate_job_log_file()
+
+
 def launch():
     """
-    launch hook for entry point
+    entry point launch hook
     """
     app = Archiver(
             __author__=__author__,
@@ -38,64 +42,71 @@ def launch():
 
 class Archiver(CLIApp):
     """
-    This application reads a complete staging directory, translates the
-    resulting Staging Structure into an Archive Structure and writes that
-    Archive Structure to a location.
+    takes an external location and formats it's contents into the
+    beginnings of a staging structure and writes that to disk.
     """
-
     def main(self):
         # Instantiate boilerplate parser
         self.spawn_parser(description="The UChicago LDR Tool Suite utility " +
-                          "for moving materials into the archive.",
+                          "for moving materials into archive structures.",
                           epilog="{}\n".format(self.__copyright__) +
                           "{}\n".format(self.__author__) +
                           "{}".format(self.__email__))
         # Add application specific flags/arguments
-        self.parser.add_argument("directory", type=str, action='store',
-                                 help="Enter the stage directory that is" +
-                                 " ready to be archived")
-        self.parser.add_argument("origin_root", type=str, action='store',
-                                 help="Enter the root of the directory " +
-                                 "entered")
-        self.parser.add_argument("--archive", type=str, action='store',
-                                 help="Use this to specify a non-default " +
-                                 "archive location",
-                                 default="/data/repository/archive")
-        self.parser.add_argument("--group", type=str, action='store',
-                                 help="Enter the name of the group that" +
-                                 " should own the files in the archive.", default="repository")
-        self.parser.add_argument("--user", type=str, action='store',
-                                 help="Enter the name of the user who " +
-                                 "should own the files in the archive.", default="repository")
-        self.parser.add_argument(
-            "--dry-run", help="Use this flag if you don't actually want to " +
-            "change ownership of the files", action='store_true', default=False)
+        self.parser.add_argument("stage_id", help="The identifying name " +
+                                 "for the new staging directory",
+                                 type=str, action='store')
+        self.parser.add_argument("--staging_env", help="The path to your " +
+                                 "staging environment",
+                                 type=str,
+                                 default=None)
+        self.parser.add_argument("--lts_env", help="The path to your " +
+                                 "long term storage environment",
+                                 type=str,
+                                 default=None)
+        self.parser.add_argument("--eq_detect", help="The equality " +
+                                 "metric to use on writing, check " +
+                                 "LDRItemCopier for supported schemes.",
+                                 type=str, action='store',
+                                 default="bytes")
+
         # Parse arguments into args namespace
         args = self.parser.parse_args()
-        staging_reader = FileSystemStageReader(args.directory)
-        staging_structure = staging_reader.read()
-        transformer = StageToArchiveTransformer(staging_structure)
-        id_type, identifier = IDBuilder().build('premisID').show()
-        archive_structure = transformer.transform(defined_id=identifier)
-        writer = FileSystemArchiveWriter(archive_structure, args.archive,
-                                         args.directory)
-        writer.write()
-        stdout.write("new arf located at {}\n".format(
-            join(writer.archive_loc,
-                 writer.pairtree.get_pairtree_path())))
-        file_tree = AbsoluteFilePathTree(
-            join(args.archive, writer.pairtree.get_pairtree_path()))
 
-        if not args.dry_run:
-            gid = getpwnam(args.user).pw_uid
-            uid = getgrnam(args.group).gr_gid
-            for f in file_tree:
-                if len(f.split('pairtree_root')) <= 1:
-                    pass
-                else:
-                    chown(f, uid, gid)
-                    chmod(f, 0x0750)
+        # Fire a stdout handler at our preferred verbosity
+        activate_stdout_log(args.verbosity)
+
+        # Set conf
+        self.set_conf(conf_dir=args.conf_dir, conf_filename=args.conf_file)
+
+        # App code
+
+        if args.staging_env:
+            staging_env = args.staging_env
+        else:
+            # Get it from the conf
+            pass
+
+        if args.lts_env:
+            lts_env = args.lts_env
+        else:
+            # Get it from the conf
+            pass
+
+        stage_path = join(staging_env, args.stage_id)
+        log.info("Stage Path: {}".format(stage_path))
+        log.info("Reading Stage...")
+        stage = FileSystemStageReader(stage_path).read()
+        log.info("Transforming Stage into Archive")
+        archive = StageToArchiveTransformer(stage).transform()
+        log.info("Validating Archive...")
+        if not archive.validate():
+            log.critical("Invalid Archive! Aborting!")
+            raise ValueError("Invalid Archive! Aborting!")
+        log.info("Writing Archive...")
+        FileSystemArchiveWriter(archive, lts_env, args.eq_detect).write()
+        log.info("Complete!")
 
 if __name__ == "__main__":
-    a = Archiver()
-    a.main()
+    s = Archiver()
+    s.main()

--- a/uchicagoldrtoolsuite/bit_level/app/archiver.py
+++ b/uchicagoldrtoolsuite/bit_level/app/archiver.py
@@ -66,6 +66,10 @@ class Archiver(CLIApp):
                                  "long term storage environment",
                                  type=str,
                                  default=None)
+        self.parser.add_argument("--live_premis_env", help="The path to your " +
+                                 "live PREMIS environment",
+                                 type=str,
+                                 default=None)
         self.parser.add_argument("--eq_detect", help="The equality " +
                                  "metric to use on writing, check " +
                                  "LDRItemCopier for supported schemes.",
@@ -94,6 +98,12 @@ class Archiver(CLIApp):
             lts_env = self.conf.get("Paths",
                                     "long_term_storage_environment_path")
 
+        if args.live_premis_env:
+            live_premis_env = args.live_premis_env
+        else:
+            live_premis_env = self.conf.get("Paths",
+                                            "live_premis_environment_path")
+
         stage_path = join(staging_env, args.stage_id)
         log.info("Stage Path: {}".format(stage_path))
         log.info("Reading Stage...")
@@ -110,7 +120,8 @@ class Archiver(CLIApp):
             )
         )
         log.info("Writing Archive...")
-        FileSystemArchiveWriter(archive, lts_env, args.eq_detect).write()
+        FileSystemArchiveWriter(archive, lts_env, live_premis_env,
+                                args.eq_detect).write()
         log.info("Complete!")
 
 if __name__ == "__main__":

--- a/uchicagoldrtoolsuite/bit_level/app/archiver.py
+++ b/uchicagoldrtoolsuite/bit_level/app/archiver.py
@@ -1,5 +1,7 @@
 from os.path import join, dirname, expanduser, expandvars
 
+from pypairtree.utils import identifier_to_path
+
 from uchicagoldrtoolsuite.core.app.abc.cliapp import CLIApp
 from uchicagoldrtoolsuite.core.lib.masterlog import \
     spawn_logger, \
@@ -84,14 +86,13 @@ class Archiver(CLIApp):
         if args.staging_env:
             staging_env = args.staging_env
         else:
-            # Get it from the conf
-            pass
+            staging_env = self.conf.get("Paths", "staging_environment_path")
 
         if args.lts_env:
             lts_env = args.lts_env
         else:
-            # Get it from the conf
-            pass
+            lts_env = self.conf.get("Paths",
+                                    "long_term_storage_environment_path")
 
         stage_path = join(staging_env, args.stage_id)
         log.info("Stage Path: {}".format(stage_path))
@@ -103,6 +104,11 @@ class Archiver(CLIApp):
         if not archive.validate():
             log.critical("Invalid Archive! Aborting!")
             raise ValueError("Invalid Archive! Aborting!")
+        log.info(
+            "Archive Path: {}".format(
+                identifier_to_path(archive.identifier, root=lts_env)
+            )
+        )
         log.info("Writing Archive...")
         FileSystemArchiveWriter(archive, lts_env, args.eq_detect).write()
         log.info("Complete!")

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/abc/converter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/abc/converter.py
@@ -23,10 +23,21 @@ class Converter(metaclass=ABCMeta):
         self._source_materialsuite = None
         self._working_dir = None
         self._timeout = None
+        self._target_extension = None
 
         self.set_source_materialsuite(input_materialsuite)
         self.set_working_dir(working_dir)
         self.set_timeout(timeout)
+
+    def get_target_extension(self):
+        return self._target_extension
+
+    def set_target_extension(self, x):
+        if not isinstance(x, str):
+            raise TypeError()
+        if not x.startswith("."):
+            raise ValueError("Extensions must begin with '.'")
+        self._target_extension = x
 
     def get_claimed_mimes(self):
         return self._claimed_mimes
@@ -63,6 +74,12 @@ class Converter(metaclass=ABCMeta):
         )
 
         if conv_premis:
+
+            conv_premis.get_object_list()[0].set_originalName(
+                orig_premis.get_object_list()[0].get_originalName() +
+                ".presform" + self.target_extension
+            )
+
             conv_premis.get_object_list()[0].add_linkingEventIdentifier(
                 self._build_linkingEventIdentifier(conv_event)
             )
@@ -251,3 +268,4 @@ class Converter(metaclass=ABCMeta):
     source_materialsuite = property(get_source_materialsuite, set_source_materialsuite)
     working_dir = property(get_working_dir, set_working_dir)
     timeout = property(get_timeout, set_timeout)
+    target_extension = property(get_target_extension, set_target_extension)

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/audioconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/audioconverter.py
@@ -84,6 +84,7 @@ class AudioConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.target_extension = ".flac"
         self.ffmpeg_path = data_transfer_obj.get('ffmpeg_path', None)
         if self.ffmpeg_path is None:
             raise ValueError('No ffmpeg_path specified in the data ' +
@@ -134,7 +135,7 @@ class AudioConverter(Converter):
         # Where we are aiming the LibreOffice CLI converter
         outdir = join(self.working_dir, str(uuid1()))
         makedirs(outdir)
-        conv_file_path = join(outdir, orig_name+".presform.flac")
+        conv_file_path = join(outdir, orig_name+".presform" + self.target_extension)
         makedirs(dirname(conv_file_path), exist_ok=True)
 
         # Fire 'er up
@@ -186,7 +187,7 @@ class AudioConverter(Converter):
         if presform_ldrpath and conv_file_premis_rec:
             log.debug("Adding PresformMaterialSuite to original MaterialSuite")
             presform_ms = PresformMaterialSuite()
-            presform_ms.set_extension(".flac")
+            presform_ms.set_extension(self.target_extension)
             presform_ms.content = presform_ldrpath
             presform_premis_path = join(self.working_dir, str(uuid1()))
             conv_file_premis_rec.write_to_file(presform_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/imageconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/imageconverter.py
@@ -83,6 +83,7 @@ class ImageConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.target_extension = ".tif"
         self.ffmpeg_path = data_transfer_obj.get('ffmpeg_path', None)
         if self.ffmpeg_path is None:
             raise ValueError('No ffmpeg_path specified in the data ' +
@@ -133,7 +134,7 @@ class ImageConverter(Converter):
         # Where we are aiming the LibreOffice CLI converter
         outdir = join(self.working_dir, str(uuid1()))
         makedirs(outdir)
-        conv_file_path = join(outdir, orig_name+".presform.tif")
+        conv_file_path = join(outdir, orig_name+".presform" + self.target_extension)
         makedirs(dirname(conv_file_path), exist_ok=True)
 
         # Fire 'er up
@@ -185,7 +186,7 @@ class ImageConverter(Converter):
         if presform_ldrpath and conv_file_premis_rec:
             log.debug("Adding PresformMaterialSuite to original MaterialSuite")
             presform_ms = PresformMaterialSuite()
-            presform_ms.set_extension(".tif")
+            presform_ms.set_extension(self.target_extension)
             presform_ms.content = presform_ldrpath
             presform_premis_path = join(self.working_dir, str(uuid1()))
             conv_file_premis_rec.write_to_file(presform_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/officetocsvconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/officetocsvconverter.py
@@ -76,6 +76,7 @@ class OfficeToCSVConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.target_extension = ".csv"
         self.libre_office_path = data_transfer_obj.get('libre_office_path', None)
         if self.libre_office_path is None:
             raise ValueError('No libre_office_path specificed in the data' +
@@ -180,7 +181,7 @@ class OfficeToCSVConverter(Converter):
         if presform_ldrpath and conv_file_premis_rec:
             log.debug("Adding PresformMaterialSuite to original MaterialSuite")
             presform_ms = PresformMaterialSuite()
-            presform_ms.set_extension(".csv")
+            presform_ms.set_extension(self.target_extension)
             presform_ms.content = presform_ldrpath
             presform_premis_path = join(self.working_dir, str(uuid1()))
             conv_file_premis_rec.write_to_file(presform_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/officetopdfconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/officetopdfconverter.py
@@ -104,6 +104,7 @@ class OfficeToPDFConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.target_extension = ".pdf"
         self.libre_office_path = data_transfer_obj.get('libre_office_path', None)
         if self.libre_office_path is None:
             raise ValueError('No libre_office_path specificed in the data' +
@@ -208,7 +209,7 @@ class OfficeToPDFConverter(Converter):
         if presform_ldrpath and conv_file_premis_rec:
             log.debug("Adding PresformMaterialSuite to original MaterialSuite")
             presform_ms = PresformMaterialSuite()
-            presform_ms.set_extension(".pdf")
+            presform_ms.set_extension(self.target_extension)
             presform_ms.content = presform_ldrpath
             presform_premis_path = join(self.working_dir, str(uuid1()))
             conv_file_premis_rec.write_to_file(presform_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/officetotxtconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/officetotxtconverter.py
@@ -88,6 +88,7 @@ class OfficeToTXTConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.target_extension = ".txt"
         self.libre_office_path = data_transfer_obj.get('libre_office_path', None)
         if self.libre_office_path is None:
             raise ValueError('No libre_office_path specificed in the data' +
@@ -192,7 +193,7 @@ class OfficeToTXTConverter(Converter):
         if presform_ldrpath and conv_file_premis_rec:
             log.debug("Adding PresformMaterialSuite to original MaterialSuite")
             presform_ms = PresformMaterialSuite()
-            presform_ms.set_extension(".txt")
+            presform_ms.set_extension(self.target_extension)
             presform_ms.content = presform_ldrpath
             presform_premis_path = join(self.working_dir, str(uuid1()))
             conv_file_premis_rec.write_to_file(presform_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/converters/videoconverter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/converters/videoconverter.py
@@ -83,6 +83,7 @@ class VideoConverter(Converter):
         """
         super().__init__(input_materialsuite,
                          working_dir=working_dir, timeout=timeout)
+        self.target_extension = ".avi"
         self.ffmpeg_path = data_transfer_obj.get('ffmpeg_path', None)
         if self.ffmpeg_path is None:
             raise ValueError('No ffmpeg_path specified in the data' +
@@ -133,7 +134,7 @@ class VideoConverter(Converter):
         # Where we are aiming the LibreOffice CLI converter
         outdir = join(self.working_dir, str(uuid1()))
         makedirs(outdir)
-        conv_file_path = join(outdir, orig_name+".presform.avi")
+        conv_file_path = join(outdir, orig_name+".presform" + self.target_extension)
         makedirs(dirname(conv_file_path), exist_ok=True)
 
         # Fire 'er up
@@ -186,7 +187,7 @@ class VideoConverter(Converter):
         if presform_ldrpath and conv_file_premis_rec:
             log.debug("Adding PresformMaterialSuite to original MaterialSuite")
             presform_ms = PresformMaterialSuite()
-            presform_ms.set_extension(".avi")
+            presform_ms.set_extension(self.target_extension)
             presform_ms.content = presform_ldrpath
             presform_premis_path = join(self.working_dir, str(uuid1()))
             conv_file_premis_rec.write_to_file(presform_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/readers/abc/archiveserializationreader.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/abc/archiveserializationreader.py
@@ -1,0 +1,19 @@
+from abc import ABCMeta, abstractmethod
+from uuid import uuid1
+
+from .abc.serializationreader import SerializationReader
+from ...structures.archive import Archive
+
+
+__author__ = "Brian Balsamo"
+__email__ = "balsamo@uchicago.edu"
+__company__ = "The University of Chicago Library"
+__copyright__ = "Copyright University of Chicago, 2016"
+__publication__ = ""
+__version__ = "0.0.1dev"
+
+
+class ArchiveSerializationReader(SerializationReader, metaclass=ABCMeta):
+    @abstractmethod
+    def __init__(self):
+        self.set_struct(Archive(str(uuid1())))

--- a/uchicagoldrtoolsuite/bit_level/lib/readers/filesystemarchivereader.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/filesystemarchivereader.py
@@ -1,0 +1,180 @@
+from os.path import join, isdir, isfile, splitext
+from json import load
+
+from pypremis.lib import PremisRecord
+
+from pypairtree.pairtree import PairTree
+from pypairtree.utils import identifier_to_path
+
+from .abc.archiveserializationreader import ArchiveSerializationReader
+from ..structures.segment import Segment
+from ..structures.materialsuite import MaterialSuite
+from ..structures.presformmaterialsuite import PresformMaterialSuite
+from ..ldritems.ldrpath import LDRPath
+
+
+class FileSystemArchiveReader(ArchiveSerializationReader):
+    def __init__(self):
+        super().__init__()
+
+    def _read_skeleton(self, lts_path, identifier):
+        arch_root = join(lts_path, str(identifier_to_path(identifier)), "arf")
+        pairtree_root = join(arch_root, "pairtree_root")
+        admin_root = join(arch_root, "admin")
+        if not isdir(arch_root):
+            raise ValueError("No such identifier ({}) in the long term " +
+                             "storage environment ({})!".format(
+                                 lts_path, identifier))
+        if not isdir(pairtree_root):
+            raise ValueError("No pairtree root in Archive ({})!".format(
+                identifier))
+        if not isdir(admin_root):
+            raise ValueError("No admin directory in Archive ({})!".format(
+                identifier))
+
+        admin_manifest_path = join(admin_root, "admin_manifest.json")
+        data_manifest_path = join(admin_root, "data_manifest.json")
+        accrec_dir_path = join(admin_root, "accession_records")
+        adminnotes_path = join(admin_root, "adminnotes")
+        legalnotes_path = join(admin_root, "legalnotes")
+
+        if not isfile(admin_manifest_path):
+            raise ValueError("No admin_manifest.json in Archive ({})!".format(
+                identifier))
+        if not isfile(data_manifest_path):
+            raise ValueError("No data_manifest.json in Archive ({})!".format(
+                identifier))
+        if not isdir(accrec_dir_path):
+            raise ValueError()
+        if not isdir(adminnotes_path):
+            raise ValueError()
+        if not isdir(legalnotes_path):
+            raise ValueError()
+
+        return arch_root, pairtree_root, admin_root, admin_manifest_path, \
+            data_manifest_path, accrec_dir_path, adminnotes_path, \
+            legalnotes_path
+
+    def read(self, lts_path, identifier):
+        self.get_struct().identifier = identifier
+        arch_root, pairtree_root, admin_root, admin_manifest_path, \
+            data_manifest_path, accrec_dir_path, adminnotes_path, \
+            legalnotes_path = self._read_skeleton(lts_path, identifier)
+
+        pairtree = PairTree(containing_dir=arch_root)
+        pairtree.gather_objects()
+
+        data_manifest = None
+        with open(data_manifest_path, 'r') as f:
+            data_manifest = load(f)
+
+        if not data_manifest['acc_id'] == identifier:
+            raise ValueError("Identifier mismatch with data_manifest.json")
+
+        ids_from_manifest = [x['identifier'] for x in data_manifest['objs']]
+        num_ids_from_manifest = len(ids_from_manifest)
+        i = 0
+        for obj in pairtree.objects:
+            if obj.identifier not in ids_from_manifest:
+                raise ValueError("ID on filesystem that isn't in the " +
+                                 "manifest: {}".format(obj.identifier))
+            i += 1
+        if i != num_ids_from_manifest:
+            raise ValueError("ID(s) in the manifest that aren't on the " +
+                             "file system!")
+
+        for ms_entry in data_manifest['objs']:
+            # Create a segment if one doesn't exist with that identifier
+            # otherwise grab the existing segment from the structure
+            is_presform = False
+            seg = None
+            for x in self.get_struct().segment_list:
+                if x.identifier == ms_entry['origin_segment']:
+                    seg = x
+            if seg is None:
+                seg = Segment(
+                    ms_entry['origin_segment'].split("-")[0],
+                    int(ms_entry['origin_segment'].split("-")[1])
+                )
+                self.get_struct().add_segment(seg)
+            premis_path = None
+            for bytestream_entry in ms_entry['bytestreams']:
+                if bytestream_entry['type'] == "PREMIS":
+                    premis_path = bytestream_entry['dst']
+                    premis = PremisRecord(frompath=premis_path)
+                    try:
+                        relationships = premis.get_object_list()[0].get_relationship()
+                    except KeyError:
+                        relationships = []
+                    for x in relationships:
+                        if x.get_relationshipType() == "derivation" and \
+                                x.get_relationshipSubType() == "has Source":
+                            is_presform = True
+            if not is_presform:
+                seg.add_materialsuite(
+                    self._pack_materialsuite(ms_entry,
+                                            data_manifest)
+                )
+
+        return self.get_struct()
+
+    def _pack_materialsuite(self, ms_entry, data_manifest):
+        ms = MaterialSuite()
+        premis = None
+        for bytestream_entry in ms_entry['bytestreams']:
+            presform_ids = []
+            if bytestream_entry['type'] == "file content":
+                ms.content = LDRPath(bytestream_entry['dst'])
+            if bytestream_entry['type'] == "technical metadata":
+                ms.add_technicalmetadata(LDRPath(bytestream_entry['dst']))
+            if bytestream_entry['type'] == "PREMIS":
+                ms.premis = LDRPath(bytestream_entry['dst'])
+                premis = PremisRecord(frompath=bytestream_entry['dst'])
+                try:
+                    relationships = premis.get_object_list()[0].get_relationship()
+                except KeyError:
+                    relationships = []
+                for x in relationships:
+                    if x.get_relationshipType() == "derivation" and \
+                            x.get_relationshipSubType == "is Source of":
+                        presform_ids.append(x.get_relatedObjectIdentifier()[0].\
+                                            get_relatedObjectIdentifierValue())
+            for x in presform_ids:
+                entry = None
+                for y in data_manifest['objs']:
+                    if x == y['identifier']:
+                        entry = y
+                ms.add_presform(self._pack_presform_materialsuite(entry,
+                                                                  data_manifest))
+        return ms
+
+    def _pack_presform_materialsuite(self, ms_entry, data_manifest):
+        ms = PresformMaterialSuite()
+        premis = None
+        for bytestream_entry in ms_entry['bytestreams']:
+            presform_ids = []
+            if bytestream_entry['type'] == "file content":
+                ms.content = LDRPath(bytestream_entry['dst'])
+            if bytestream_entry['type'] == "technical metadata":
+                ms.add_technicalmetadata(LDRPath(bytestream_entry['dst']))
+            if bytestream_entry['type'] == "PREMIS":
+                ms.premis = LDRPath(bytestream_entry['dst'])
+                premis = PremisRecord(frompath=bytestream_entry['dst'])
+                try:
+                    relationships = premis.get_object_list()[0].get_relationship()
+                except KeyError:
+                    relationships = []
+                for x in relationships:
+                    if x.get_relationshipType() == "derivation" and \
+                            x.get_relationshipSubType == "is Source of":
+                        presform_ids.append(x.get_relatedObjectIdentifier()[0].\
+                                            get_relatedObjectIdentifierValue())
+                ext = splitext(premis.get_object_list()[0].get_originalName())
+                ms.extension = ext
+                for x in presform_ids:
+                    entry = None
+                    for y in data_manifest['objs']:
+                        if x == y['identifier']:
+                            entry = y
+                    ms.add_presform(self._pack_presform_materialsuite(entry))
+        return ms

--- a/uchicagoldrtoolsuite/bit_level/lib/readers/filesystemmaterialsuitepackager.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/filesystemmaterialsuitepackager.py
@@ -1,6 +1,7 @@
 from os import scandir
 from os.path import join, dirname, basename, isfile, splitext
 from re import compile as re_compile
+from re import escape as re_escape
 from json import dumps
 
 from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
@@ -116,7 +117,7 @@ class FileSystemMaterialSuitePackager(MaterialSuitePackager):
         presforms = []
         presform_filename_pattern = re_compile(
             "^{}\.presform(\.[a-zA-Z0-9]*)?$".format(
-                self.file_name
+                re_escape(self.file_name)
             )
         )
         containing_folder_path = join(self.data_fullpath,

--- a/uchicagoldrtoolsuite/bit_level/lib/readers/filesystempresformmaterialsuitepackager.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/filesystempresformmaterialsuitepackager.py
@@ -1,6 +1,7 @@
 from os import scandir
 from os.path import join, dirname, basename, isfile, splitext
 from re import compile as re_compile
+from re import escape as re_escape
 from json import dumps
 
 from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
@@ -112,7 +113,7 @@ class FileSystemPresformMaterialSuitePackager(PresformMaterialSuitePackager):
         presforms = []
         presform_filename_pattern = re_compile(
             "^{}\.presform(\.[a-zA-Z0-9]*)?$".format(
-                self.file_name
+                re_escape(self.file_name)
             )
         )
         containing_folder_path = join(self.data_fullpath,

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/abc/structure.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/abc/structure.py
@@ -25,7 +25,7 @@ class Structure(metaclass=ABCMeta):
     def validate(self):
         for thing in self.get_required_parts():
             if  getattr(self, thing, None) == None:
-                return False
+                return (False, "missing rec part: {}".format(thing))
         return True
 
     def get_required_parts(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
@@ -1,13 +1,20 @@
+from json import dumps
+
+from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
 from .abc.structure import Structure
 from ..ldritems.abc.ldritem import LDRItem
 from .segment import Segment
+from .presformmaterialsuite import PresformMaterialSuite
 
-__author__ = "Tyler Danstrom"
-__email__ = "tdanstrom@uchicago.edu"
+__author__ = "Tyler Danstrom, Brian Balsamo"
+__email__ = "tdanstrom@uchicago.edu, balsamo@uchicago.edu"
 __company__ = "The University of Chicago Library"
 __copyright__ = "Copyright University of Chicago, 2016"
 __publication__ = ""
 __version__ = "0.0.1dev"
+
+
+log = spawn_logger(__name__)
 
 
 class Archive(Structure):
@@ -15,68 +22,174 @@ class Archive(Structure):
     The structure which holds archival contents in the archive environment.
     """
 
-    def __init__(self, defined_id=None, make_noid=False):
+    def __init__(self, identifier):
+        self._identifier = None
+        self._segment = []
+        self._accessionrecord = []
+        self._adminnote = []
+        self._legalnote = []
+        self._required_parts = None
+
         self.required_parts = ['identifier', 'segment_list',
                                'accessionrecord_list', 'admninnote_list',
                                'legalnote_list']
-        if defined_id:
-            self.identifier = defined_id
-        else:
-            self.identifier = get_archivable_identifier(noid=make_noid)
+        self.identifier = identifier
         self.segment_list = []
         self.accessionrecord_list = []
         self.legalnote_list = []
         self.adminnote_list = []
 
-    def validate(self):
-        super().validate()
-        big_list = self.accessionrecord_list + self.adminnote_list +\
-            self.legalnote_list
-
-        for n_thing in self.segment_list:
-            if not isinstance(n_thing, Segment):
+    def _validate_materialsuite(self, materialsuite):
+        if isinstance(materialsuite, PresformMaterialSuite):
+            if not isinstance(materialsuite.extension, str):
                 return False
+        if not isinstance(materialsuite.content, LDRItem):
+            return False
+        if not isinstance(materialsuite.premis, LDRItem):
+            return False
+        if not len(materialsuite.technicalmetadata_list) > 0:
+            return False
+        if materialsuite.presform_list:
+            for x in materialsuite.presform_list:
+                self._validate_materialsuite(x)
         return True
 
-    def iterate_through_a_list(self, a_list):
-        for n_item in a_list:
-            yield n_item
+    def validate(self):
+        for segment in self.segment_list:
+            for materialsuite in segment.materialsuite_list:
+                if self._validate_materialsuite(materialsuite) is False:
+                    return False
+        if len(self.accessionrecord_list) < 1:
+            return False
+        return super().validate()
 
-    def validate_input(self, input):
-        for n_input in input:
-            if isinstance(n_input, LDRItem):
-                pass
-            else:
-                raise ValueError("must pass an ldritem; you passed " +
-                                 " something of type {}".
-                                 format(type(n_input).__name__))
+    def __repr__(self):
+        attr_dict = {
+            'identifier': self.identifier,
+            'segment_list': [str(x) for x in self.segment_list],
+            'accessionrecord_list': [str(x) for x in self.accessionrecord_list],
+            'adminnote_list': [str(x) for x in self.adminnote_list],
+            'legalnote_list': [str(x) for x in self.legalnote_list]
+        }
+        return "<Archive {}>".format(dumps(attr_dict, sort_keys=True))
 
-    def get_segments_list(self):
-        return self._segment_list
+    def get_identifier(self):
+        return self._identifier
 
-    def set_segments_list(self, value):
-        if not isinstance(value, list):
-            raise ValueError("Must pass only a Segment Structure to" +
-                             " segments_list")
+    def set_identifier(self, identifier):
+        log.debug("Archive({}) identifier being set to {}".format(str(self.identifier), self.identifier))
+        self._identifier = identifier
+        log.debug(
+            "Archive identifier set to {}".format(identifier)
+        )
+
+    def get_segment_list(self):
+        return self._segment
+
+    def set_segment_list(self, seg_list):
+        self.del_segment_list()
+        for x in seg_list:
+            self.add_segment(x)
+
+    def del_segment_list(self):
+        while self.get_segment_list():
+            self.pop_segment()
+
+    def add_segment(self, segment):
+        if not isinstance(segment, Segment):
+            raise ValueError('only Segments can be added to the segments_list')
+        self._segment.append(segment)
+        log.debug("Added Segment({}) to Archive({}): {}".format(segment.identifier, self.identifier, str(segment)))
+
+    def get_segment(self, index):
+        return self.get_segment_list()[index]
+
+    def pop_segment(self, index=None):
+        if index is None:
+            x = self.get_segment_list().pop()
         else:
-            self._segment_list = value
+            x = self.get_segment_list().pop(index)
+        log.debug("Popped segment({}) from Archive({})".format(x.identifier, self.identifier))
+        return x
 
-    def get_premis_list(self):
-        return self._premis_list
+    def get_accessionrecord_list(self):
+        return self._accessionrecord
 
-    def set_premis_list(self, value):
-        if not self.validate_input(value):
-            raise ValueError("premis_list can only contain LDRItem " +
-                             "sub-class instances")
+    def set_accessionrecord_list(self, acc_rec_list):
+        self.del_accessionrecord_list()
+        for x in acc_rec_list:
+            self.add_accessionrecord(x)
+
+    def del_accessionrecord_list(self):
+        while self.get_accessionrecord_list():
+            self.pop_accessionrecord()
+
+    def add_accessionrecord(self, accrec):
+        self._accessionrecord.append(accrec)
+        log.debug("Added accession record to Archive({}): {}".format(self.identifier, str(accrec)))
+
+    def get_accessionrecord(self, index):
+        return self.get_accessionrecord_list()[index]
+
+    def pop_accessionrecord(self, index=None):
+        if index is None:
+            x = self.get_accessionrecord_list.pop()
         else:
-            self._premis_list = value
+            x = self.get_accessionrecord_list.pop(index)
+        log.debug("Popped accession record from Archive({}): {}".format(self.identifier, str(x)))
+        return x
 
-    def get_accession_record(self):
-        return self._Accession_record_list
+    def get_adminnote_list(self):
+        return self._adminnote
 
-    def set_accession_record(self, value):
-        self.validate_input(value)
-        self._data_object = value
+    def set_adminnote_list(self, adminnotelist):
+        self.del_adminnote_list()
+        for x in adminnotelist:
+            self.add_adminnote(x)
+
+    def del_adminnote_list(self):
+        while self.get_adminnote_list():
+            self.pop_adminnote()
+
+    def add_adminnote(self, adminnote):
+        self.get_adminnote_list().append(adminnote)
+        log.debug("Added adminnote to Archive({}): {}".format(self.identifier, str(adminnote)))
+
+    def get_adminnote(self, index):
+        return self.get_adminnote_list()[index]
+
+    def pop_adminnote(self, index=None):
+        if index is None:
+            x = self.get_adminnote_list().pop()
+        else:
+            x = self.get_adminnote_list().pop(index)
+        log.debug("Popped adminnote from Archive({}): {}".format(self.identifier, str(x)))
+        return x
+
+    def get_legalnote_list(self):
+        return self._legalnote
+
+    def set_legalnote_list(self, legalnote_list):
+        self.del_legalnote_list()
+        for x in legalnote_list:
+            self.add_legalnote(x)
+
+    def del_legalnote_list(self):
+        while self.get_legalnote_list():
+            self.pop_legalnote()
+
+    def add_legalnote(self, legalnote):
+        self.get_legalnote_list().append(legalnote)
+        log.debug("Added legalnote to Archive: {}".format(str(legalnote)))
+
+    def get_legalnote(self, index):
+        return self.get_legalnote_list()[index]
+
+    def pop_legalnote(self, index=None):
+        if index is None:
+            return self.get_legalnote_list().pop()
+        else:
+            return self.get_legalnote_list().pop(index)
 
     def get_required_parts(self):
         return self._required_parts
@@ -84,7 +197,18 @@ class Archive(Structure):
     def set_required_parts(self, value):
         self._required_parts = value
 
+    identifier = property(get_identifier,
+                          set_identifier)
+    segment_list = property(get_segment_list,
+                            set_segment_list,
+                            del_segment_list)
+    accessionrecord_list = property(get_accessionrecord_list,
+                                    set_accessionrecord_list,
+                                    del_accessionrecord_list)
+    adminnote_list = property(get_adminnote_list,
+                              set_adminnote_list,
+                              del_adminnote_list)
+    legalnote_list = property(get_legalnote_list,
+                              set_legalnote_list,
+                              del_legalnote_list)
     required_parts = property(get_required_parts, set_required_parts)
-    accession_record = property(get_accession_record, set_accession_record)
-    segment_list = property(get_segments_list, set_segments_list)
-    premis_list = property(get_premis_list, set_premis_list)

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
@@ -31,7 +31,7 @@ class Archive(Structure):
         self._required_parts = None
 
         self.required_parts = ['identifier', 'segment_list',
-                               'accessionrecord_list', 'admninnote_list',
+                               'accessionrecord_list', 'adminnote_list',
                                'legalnote_list']
         self.identifier = identifier
         self.segment_list = []
@@ -58,9 +58,9 @@ class Archive(Structure):
         for segment in self.segment_list:
             for materialsuite in segment.materialsuite_list:
                 if self._validate_materialsuite(materialsuite) is False:
-                    return False
+                    return (False, "bad materialsuite")
         if len(self.accessionrecord_list) < 1:
-            return False
+            return (False, "no accrec")
         return super().validate()
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
@@ -58,9 +58,9 @@ class Archive(Structure):
         for segment in self.segment_list:
             for materialsuite in segment.materialsuite_list:
                 if self._validate_materialsuite(materialsuite) is False:
-                    return (False, "bad materialsuite")
+                    return False
         if len(self.accessionrecord_list) < 1:
-            return (False, "no accrec")
+            return False
         return super().validate()
 
     def __repr__(self):

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/stage.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/stage.py
@@ -1,4 +1,5 @@
 from json import dumps
+
 from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
 from .abc.structure import Structure
 from .segment import Segment

--- a/uchicagoldrtoolsuite/bit_level/lib/transformers/abc/transformer.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/transformers/abc/transformer.py
@@ -12,7 +12,7 @@ __version__ = "0.0.1dev"
 class Transformer(metaclass=ABCMeta):
     """The Transformer abstract class should be used as the base class for all
     transformer concrete classes
-    
+
     The transformer's purpose is to take an instance of one type of Structure a
     and transform it into an instance of a different type of Structure.
     """
@@ -22,12 +22,12 @@ class Transformer(metaclass=ABCMeta):
         be the output
 
         The purpose of this method is implement the conversion process
-        of making one type of Structure into another. 
+        of making one type of Structure into another.
         """
         pass
 
     def get_origin_structure(self):
-        """returns the origin structure instance or the original type of 
+        """returns the origin structure instance or the original type of
         structure
         """
         return self._origin_structure

--- a/uchicagoldrtoolsuite/bit_level/lib/transformers/archivetostagetransformer.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/transformers/archivetostagetransformer.py
@@ -1,0 +1,104 @@
+from uuid import uuid4
+
+from uchicagoldrtoolsuite.core.lib.ark import Ark
+from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
+from .abc.transformer import Transformer
+from ..structures.archive import Archive
+from ..structures.stage import Stage
+
+__author__ = "Tyler Danstrom, Brian Balsamo"
+__email__ = " tdanstrom@uchicago.edu, balsamo@uchicago.edu"
+__company__ = "The University of Chicago Library"
+__copyright__ = "Copyright University of Chicago, 2016"
+__publication__ = ""
+__version__ = "0.0.1dev"
+
+
+log = spawn_logger(__name__)
+
+
+class ArchiveToStageTransformer(Transformer):
+    """The StageToARrchiveTransformer takes an instance of a Stage structure
+    and copies its contents into an instance of an Archive structure
+    """
+    def __init__(self, origin_structure):
+        """instantiates an instance of a StageToARrchiveTansformer
+
+        It starts with the origin structure passed as a parameter
+        and sets an empty destination structure.
+
+        ___Args__
+        1. origin_structure (Archive) : a fully realized instance of a
+        Archive structure
+        """
+        self.origin_structure = origin_structure
+        self.destination_structure = None
+
+    def transform(self, stage_identifier=None):
+        """returns a fully realized Archive structure containing the contents
+        of the origin Stage structure.
+
+        It copies the contents of the Stage structure into the new Archive structure
+        and sets the data attribute destination_structure before returning said
+        destination structure data attribute value.
+        """
+        if self.destination_structure is not None:
+            raise TypeError("a transformation already occured.")
+        if stage_identifier is None:
+            stage_identifier = uuid4().hex
+        self.destination_structure = Stage(stage_identifier)
+
+        for n_segment in self.origin_structure.segment_list:
+            self.destination_structure.add_segment(
+                n_segment
+            )
+
+        for n_accessionrecord in self.origin_structure.accessionrecord_list:
+            self.destination_structure.add_accessionrecord(
+                n_accessionrecord
+            )
+
+        for n_legalnote in self.origin_structure.legalnote_list:
+            self.destination_structure.add_legalnote(
+                n_legalnote
+            )
+
+        for n_adminnote in self.origin_structure.adminnote_list:
+            self.destination_structure.add_adminnote(
+                n_adminnote
+            )
+
+        return self.destination_structure
+
+    def get_origin_structure(self):
+        """returns the origin structure, in this case a fully-realized Stage structure
+        """
+        return self._origin_structure
+
+    def set_origin_structure(self, value):
+        """sets the origin structure: it will only accept a Stage structure
+        """
+        if isinstance(value, Archive):
+            self._origin_structure = value
+        else:
+            raise ValueError("ArchiveToStageTransformerr must have an " +
+                             "instace of an Archive in origin_structure")
+
+    def get_destination_structure(self):
+        """returns the destination structure, or the structure created from transform method
+        """
+        return self._destination_structure
+
+    def set_destination_structure(self, value):
+        """sets the destination structure, an Archive structure
+        """
+        self._destination_structure = value
+
+    def __repr__(self):
+        return "< transform from archive {} to stage {}".\
+            format(id(self.origin_structure),
+                   id(self.destination_structure))
+
+    destination_structure = property(get_destination_structure,
+                                     set_destination_structure)
+    origin_structure = property(get_origin_structure, set_origin_structure)

--- a/uchicagoldrtoolsuite/bit_level/lib/transformers/stagetoarchivetransformer.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/transformers/stagetoarchivetransformer.py
@@ -1,14 +1,18 @@
-
-from ..structures.archive import Archive
+from uchicagoldrtoolsuite.core.lib.ark import Ark
+from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
 from .abc.transformer import Transformer
+from ..structures.archive import Archive
 from ..structures.stage import Stage
 
-__author__ = "Tyler Danstrom"
-__email__ = " tdanstrom@uchicago.edu"
+__author__ = "Tyler Danstrom, Brian Balsamo"
+__email__ = " tdanstrom@uchicago.edu, balsamo@uchicago.edu"
 __company__ = "The University of Chicago Library"
 __copyright__ = "Copyright University of Chicago, 2016"
 __publication__ = ""
 __version__ = "0.0.1dev"
+
+
+log = spawn_logger(__name__)
 
 
 class StageToArchiveTransformer(Transformer):
@@ -17,18 +21,18 @@ class StageToArchiveTransformer(Transformer):
     """
     def __init__(self, origin_structure):
         """instantiates an instance of a StageToARrchiveTansformer
-        
+
         It starts with the origin structure passed as a parameter
         and sets an empty destination structure.
 
         ___Args__
-        1. origin_structure (Stage) : a fully realized instance of a 
+        1. origin_structure (Stage) : a fully realized instance of a
         Stage structure
         """
         self.origin_structure = origin_structure
         self.destination_structure = None
 
-    def transform(self, defined_id=None, make_noid=False):
+    def transform(self, archive_identifier=None):
         """returns a fully realized Archive structure containing the contents
         of the origin Stage structure.
 
@@ -38,26 +42,30 @@ class StageToArchiveTransformer(Transformer):
         """
         if self.destination_structure is not None:
             raise TypeError("a transformation already occured.")
-        self.destination_structure = Archive(
-            defined_id=defined_id,
-            make_noid=make_noid
-        )
+        if archive_identifier is None:
+            archive_identifier = Ark().value
+        self.destination_structure = Archive(archive_identifier)
+
         for n_segment in self.origin_structure.segment_list:
-            self.destination_structure.segment_list.append(
+            self.destination_structure.add_segment(
                 n_segment
             )
+
         for n_accessionrecord in self.origin_structure.accessionrecord_list:
-            self.destination_structure.accessionrecord_list.append(
+            self.destination_structure.add_accessionrecord(
                 n_accessionrecord
             )
+
         for n_legalnote in self.origin_structure.legalnote_list:
-            self.destination_structure.legalnote_list.append(
+            self.destination_structure.add_legalnote(
                 n_legalnote
             )
+
         for n_adminnote in self.origin_structure.adminnote_list:
-            self.destination_structure.adminnote_list.append(
+            self.destination_structure.add_adminnote(
                 n_adminnote
             )
+
         return self.destination_structure
 
     def get_origin_structure(self):
@@ -72,7 +80,7 @@ class StageToArchiveTransformer(Transformer):
             self._origin_structure = value
         else:
             raise ValueError("StageToPairtreeTransformer must have an " +
-                             "of a Stage in origin_structure")
+                             "instace of a Stage in origin_structure")
 
     def get_destination_structure(self):
         """returns the destination structure, or the structure created from transform method

--- a/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemarchivewriter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemarchivewriter.py
@@ -1,321 +1,136 @@
-
+from json import dumps
 from os import makedirs
-from os.path import basename, dirname, exists, join, split
-from sys import stderr
+from os.path import exists, join
+from tempfile import TemporaryDirectory
+from uuid import uuid4
 
-from uchicagoldrtoolsuite.core.lib.idbuilder import IDBuilder
+from pypremis.lib import PremisRecord
 
+from pypairtree.utils import identifier_to_path
+from pypairtree.pairtree import PairTree
+from pypairtree.pairtreeobject import PairTreeObject
+from pypairtree.intraobjectbytestream import IntraObjectByteStream
+
+from uchicagoldrtoolsuite.core.lib.masterlog import spawn_logger
 from .abc.archiveserializationwriter import ArchiveSerializationWriter
-from ..structures.archive import Archive
-from ..misc.accessionrecordmodifier import AccessionRecordModifier
-from ..misc.archivefitsmodifier import ArchiveFitsModifier
-from ..misc.archivemanifestwriter import ArchiveManifestWriter
-from ..misc.archivepremismodifier import ArchivePremisModifier
-
-from ..auditors.archiveauditor import ArchiveAuditor
-from ..ldritems.ldritemcopier import LDRItemCopier
 from ..ldritems.ldrpath import LDRPath
-from ..fstools.pairtree import Pairtree
-from ..misc.premisdigestextractor import PremisDigestExtractor
+from ..ldritems.ldritemcopier import LDRItemCopier
 
-from ..misc.premisrestrictionextractor import PremisRestrictionsExtractor
-
-
-__author__ = "Tyler Danstrom"
-__email__ = " tdanstrom@uchicago.edu"
-__company__ = "The University of Chicago Library"
-__copyright__ = "Copyright University of Chicago, 2016"
+__author__ = "Brian Balsamo"
+__email__ = "balsamo@uchicago.edu"
+__company = "The University of Chicago Library"
 __publication__ = ""
 __version__ = "0.0.1dev"
 
 
+log = spawn_logger(__name__)
+
+
 class FileSystemArchiveWriter(ArchiveSerializationWriter):
     """
-    writes an archive structure to the file system as a directory.
-
-    It is instantited with an instance of an ArchiveStructure,
-    the archive root directory, and the origin root directory,
-
-    Once instantiated, the write() method should be called when ready
-    to serialize the archive structure to disk.
+    Writes an archive structure to disk utilizing PairTrees as a series
+    of directories and files.
     """
-    def __init__(self, aStructure, archive_loc, origin_loc):
+    def __init__(self, anArchive, aRoot, eq_detect="bytes"):
         """
-        initialize the writer
+        spawn a writer
 
-        __Args__
-
-        1. aStructure (StagingStructure): The structure to write
-        2. archive_loc (str): the root directory for the archive of the ldr
-        3. origin_loc (str): the root directory of the stage directory
-        being archived
         """
-        self.structure = aStructure
-        self.pairtree = Pairtree(self.structure.identifier)
-        self.audit_qualification = ArchiveAuditor(aStructure)
-        self.origin_root = split(origin_loc)[0]
-        self.identifier = IDBuilder().build('premisID')
-        self.premis_modifier = ArchivePremisModifier
-        self.fits_modifier = ArchiveFitsModifier
-        self.file_digest_extraction = PremisDigestExtractor
-        self.file_restriction_extraction = PremisRestrictionsExtractor
-        self.manifest_writer = ArchiveManifestWriter(archive_loc)
-        self.archive_loc = archive_loc
-        self.accessrecord_modifier = AccessionRecordModifier
+        super().__init__(anArchive)
+        self.lts_env_path = aRoot
+        self.eq_detect = eq_detect
+        log.debug("FileSystemArchiveWriter spawned: {}".format(str(self)))
+
+    def __repr__(self):
+        attr_dict = {
+            'lts_env_path': self.lts_env_path,
+            'eq_detect': self.eq_detect,
+            'struct': str(self.get_struct())
+        }
+        return "<FileSystemArchiveWriter {}>".format(dumps(attr_dict,
+                                                           sort_keys=True))
+
+    def _write_ark_dir(self, clobber=False):
+        ark_path = join(
+            str(identifier_to_path(self.get_struct().identifier,
+                                   root=self.lts_env_path)),
+            "arf"
+        )
+        if exists(ark_path) and not clobber:
+            err_text = "The Ark path ({}) ".format(ark_path) + \
+                "already exists in the long term storage environment. " + \
+                "Aborting."
+            log.critical(err_text)
+            raise OSError(err_text)
+        else:
+            makedirs(ark_path, exist_ok=True)
+        return ark_path
+
+    def _write_dirs_skeleton(self, ark_path):
+        admin_dir_path = join(ark_path, "admin")
+        pairtree_root = join(ark_path, "pairtree_root")
+        accession_records_dir_path = join(admin_dir_path, "accession_records")
+        adminnotes_dir_path = join(admin_dir_path, "adminnotes")
+        legalnotes_dir_path = join(admin_dir_path, "legalnotes")
+
+        for x in [admin_dir_path, pairtree_root, accession_records_dir_path,
+                  adminnotes_dir_path, legalnotes_dir_path]:
+            makedirs(x, exist_ok=True)
+        return pairtree_root, accession_records_dir_path, \
+            adminnotes_dir_path, legalnotes_dir_path
+
+    def _put_materialsuite_into_pairtree(self, materialsuite,
+                                         seg_id, pair_tree):
+        obj_id = self._get_premis_obj_id(materialsuite.premis)
+        o = PairTreeObject(identifier=obj_id, encapsulation="arf")
+        content = IntraObjectByteStream(
+            materialsuite.content,
+            intraobjectaddress="content.file"
+        )
+        premis = IntraObjectByteStream(
+            materialsuite.premis,
+            intraobjectaddress="premis.xml"
+        )
+        if len(materialsuite.technicalmetadata_list) > 1:
+            raise NotImplementedError(
+                "The Archive serializer currently only supports " +
+                "serializing a single FITs record as technical metadata."
+            )
+        fits = IntraObjectByteStream(
+            materialsuite.technicalmetadata_list[0],
+            intraobjectaddress="fits.xml"
+        )
+        o.add_bytestream(content)
+        o.add_bytestream(premis)
+        o.add_bytestream(fits)
+        pair_tree.add_object(o)
+        if materialsuite.presform_list:
+            for x in materialsuite.presform_list:
+                self._put_materialsuite_into_pairtree(x, seg_id, pair_tree)
+
+    def _get_premis_obj_id(self, premis_ldritem):
+        with TemporaryDirectory() as tmp_dir:
+            premis_path = join(tmp_dir, uuid4().hex)
+            tmp_item = LDRPath(premis_path)
+            LDRItemCopier(premis_ldritem, tmp_item).copy()
+            premis = PremisRecord(frompath=premis_path)
+            return premis.get_object_list()[0].get_objectIdentifier()[0].get_objectIdentifierValue()
 
     def write(self):
-        """
-        checks of the structure is validate and audits the contents of the
-        structure for errors.
+        log.debug("Writing Archive")
 
-        If the structure is valid and there are no errors in the audit it
-        serializes the structure to disk which includes the following steps
+        ark_path = self._write_ark_dir()
+        pairtree_root, accession_records_dir_path, adminnotes_dir_path, \
+            legalnotes_dir_path = self._write_dirs_skeleton(ark_path)
 
-        1. modifies premis records in the structure to include archive
-        information
+        data_manifest = {}
 
-        2. modifies fits technical metadata records to include archive
-        information
+        pair_tree = PairTree(containing_dir=ark_path)
 
-        3. sets up archive file serialization structure and copies contents
-        of the structure into the serialization structure
+        for seg in self.get_struct().segment_list:
+            seg_id = seg.identifier
+            for materialsuite in seg.materialsuite_list:
+                self._put_materialsuite_into_pairtree(materialsuite, seg_id,
+                                                      pair_tree)
 
-        4. extracts message digests for the resource files from premis records
-        and appends them with the new file location to the archive manifest
-
-        """
-        if self.structure.validate() and self.audit_qualification.audit():
-            pairtree_path = self.pairtree.get_pairtree_path()
-            data_dir = join(self.archive_loc, pairtree_path, 'data')
-            admin_dir = join(self.archive_loc, pairtree_path, 'admin')
-            makedirs(data_dir, exist_ok=True)
-            makedirs(admin_dir, exist_ok=True)
-            accrecord_dir = join(admin_dir, 'accessionrecord')
-            legalnote_dir = join(admin_dir, 'legalnotes')
-            adminnote_dir = join(admin_dir, 'adminnotes')
-            makedirs(accrecord_dir, exist_ok=True)
-            makedirs(legalnote_dir, exist_ok=True)
-            makedirs(adminnote_dir, exist_ok=True)
-            accrecords = []
-            for n_acc_record in self.structure.accessionrecord_list:
-                acc_filename = basename(n_acc_record.item_name)
-                LDRItemCopier(n_acc_record, LDRPath(
-                    join(accrecord_dir,
-                         acc_filename))).copy()
-                accrecords.append(join(accrecord_dir, acc_filename))
-            for n_legal_note in self.structure.legalnote_list:
-                legalnote_filename = basename(n_legal_note.item_name)
-                LDRItemCopier(n_legal_note, LDRPath(
-                    join(legalnote_dir,
-                         legalnote_filename))).copy()
-            for n_adminnote in self.structure.adminnote_list:
-                adminnote_filename = basename(n_adminnote.item_name)
-                LDRItemCopier(n_adminnote, LDRPath(
-                    join(adminnote_dir,
-                         adminnote_filename))).copy()
-            accession_restrictions = set([])
-            for n_segment in self.structure.segment_list:
-                segment_id = n_segment.label+'-'+str(n_segment.run)
-                techmd_dir = join(admin_dir, segment_id, 'TECHMD')
-                premis_dir = join(admin_dir, segment_id, 'PREMIS')
-                segment_data_dir = join(data_dir, segment_id)
-                makedirs(techmd_dir, exist_ok=True)
-                makedirs(premis_dir, exist_ok=True)
-                makedirs(segment_data_dir, exist_ok=True)
-                for n_msuite in n_segment.materialsuite_list:
-                    n_content_destination_fullpath = join(
-                        data_dir, segment_id, n_msuite.content.item_name)
-
-                    modifier = self.premis_modifier(
-                        n_msuite.premis, n_content_destination_fullpath)
-                    modifier.change_record()
-                    digest_data = self.file_digest_extraction(
-                        n_msuite.premis).extract_digests()
-                    restrictions = self.file_restriction_extraction(
-                        n_msuite.premis).extract_restrictions()
-                    for n_restriction in restrictions:
-                        accession_restrictions.add(n_restriction)
-                    self.manifest_writer.add_a_line(
-                        n_content_destination_fullpath, digest_data)
-
-                    makedirs(
-                        join(data_dir, dirname(
-                            n_msuite.content.item_name)), exist_ok=True)
-                    makedirs(
-                        join(premis_dir, dirname(
-                            n_msuite.content.item_name)), exist_ok=True)
-                    makedirs(
-                        join(techmd_dir, dirname(
-                            n_msuite.content.item_name)), exist_ok=True)
-
-                    new_premis_path = join(
-                        premis_dir, n_msuite.premis.item_name)
-                    new_content_path = join(
-                        data_dir, segment_id,
-                        n_msuite.content.item_name)
-
-                    makedirs(new_content_path, exist_ok=True)
-
-                    new_content_ldrpath = LDRPath(new_content_path)
-                    modifier.record.write_to_file(new_premis_path)
-                    LDRItemCopier(n_msuite.content, new_content_ldrpath).copy()
-
-                    for n_techmd in n_msuite.technicalmetadata_list:
-                        new_tech_record_loc = join(
-                            techmd_dir, n_techmd.item_name)
-                        new_tech_record = self.fits_modifier(
-                            n_techmd, new_tech_record_loc).modify_record()
-                        new_tech_record.write(new_tech_record_loc)
-                    if getattr(n_msuite, 'presform_list', None):
-                        for n_presform in n_msuite.presform_list:
-                            n_destination_fullpath = join(
-                                data_dir, segment_id,
-                                n_presform.content.item_name)
-                            modifier = self.premis_modifier(
-                                n_presform.premis, n_destination_fullpath)
-                            modifier.change_record()
-                            makedirs(
-                                join(data_dir, dirname(
-                                    n_presform.content.item_name)),
-                                exist_ok=True)
-                            makedirs(
-                                join(premis_dir, dirname(
-                                    n_presform.content.item_name)),
-                                exist_ok=True)
-                            makedirs(
-                                join(techmd_dir, dirname(
-                                    n_presform.content.item_name)),
-                                exist_ok=True)
-                            digest_data = self.file_digest_extraction(
-                                n_presform.premis).extract_digests()
-                            restrictions = self.file_restriction_extraction(
-                                n_presform.premis).extract_restrictions()
-                            self.manifest_writer.add_a_line(
-                                n_destination_fullpath, digest_data)
-
-                            new_premis_path = join(
-                                premis_dir, n_presform.premis.item_name)
-                            new_presform_content_path = join(
-                                data_dir, segment_id,
-                                n_presform.content.item_name)
-                            new_presform_content_ldrpath = LDRPath(
-                                new_presform_content_path)
-                            modifier.record.write_to_file(new_premis_path)
-                            LDRItemCopier(n_presform.content,
-                                 new_presform_content_ldrpath).copy()
-                        for n_techmd in n_presform.technicalmetadata_list:
-                            new_tech_record_loc = join(
-                                techmd_dir, n_techmd.item_name)
-                            new_tech_record = self.fits_modifier(
-                                n_techmd, new_tech_record_loc).modify_record()
-
-                            new_tech_record.write(new_tech_record_loc)
-                self.manifest_writer.write()
-                for a_record in accrecords:
-                    acc_modifier = self.accessrecord_modifier(
-                        LDRPath(a_record))
-                    acc_modifier.add_restriction_info(list(restrictions))
-                    acc_modifier.write(a_record)
-
-        else:
-            stderr.write(self.structure.explain_results())
-            stderr.write(self.audit_qualification.show_errors())
-
-    def get_structure(self):
-        """returns the structure that this writer serializes
-        """
-        return self._structure
-
-    def set_structure(self, value):
-        """ sets the structure attribute for this writer. It will reject any structure
-        object that it not an Archive structure.
-        """
-        if isinstance(value, Archive):
-            self._structure = value
-        else:
-            raise ValueError(
-                "FileSystemArchiveWriter reqiures an Archive structure" +
-                " in the structure attribute")
-
-    def get_pairtree(self):
-        """returns the pairtree object for the writer
-        """
-        return self._pairtree
-
-    def set_pairtree(self, value):
-        """sets the pairtree object for the writer. It will only accept
-        a Pairtree object
-        """
-        if isinstance(value, Pairtree):
-            self._pairtree = value
-        else:
-            raise ValueError(
-                "FileSystemArchiveWriter must take an instance of a " +
-                "Pairtree in the pairtree attribute")
-
-    def get_origin_root(self):
-        """returns the origin root string for the writer
-        """
-        return self._origin_root
-
-    def set_origin_root(self, value):
-        """sets the origin root for the writer. It will only accept a file
-        path that exists on the machine that the code is running on
-        """
-        if exists(value):
-            self._origin_root = value
-        else:
-            raise ValueError("{} origin root does not exist.".format(value))
-
-    def get_archive_loc(self):
-        """returns the archive root of the writer
-        """
-        return self._archive_loc
-
-    def set_archive_loc(self, value):
-        """ sets the archive root for the writer. It will only accept a filepath that
-        exists on the machine that the application is running on
-        """
-        if exists(value):
-            self._archive_loc = value
-        else:
-            raise ValueError(
-                "{} archive loc does not exist".format(value))
-
-    def get_identifier(self):
-        """ returns the identifer for the writer
-        """
-        return self._identifier
-
-    def set_identifier(self, value):
-        """sets the identifier factory for the writer
-        """
-        self._identifier = value
-
-    def get_premis_modifier(self):
-        """ returns the premis modifier for the writer
-        """
-        return self._premis_modifier
-
-    def set_premis_modifier(self, value):
-        """sets the premis modifier for the writer
-        """
-        self._premis_modifier = value
-
-    def get_fits_modifier(self):
-        """sets the fits modifier for the writer
-        """
-        return self._fits_modifier
-
-    def set_fits_modifier(self, value):
-        """returns the fits modifier for the factory
-        """
-        self._fits_modifier = value
-
-    structure = property(get_structure, set_structure)
-    pairtree = property(get_pairtree, set_pairtree)
-    origin_root = property(get_origin_root, set_origin_root)
-    archive_loc = property(get_archive_loc, set_archive_loc)
-    fits_modifer = property(get_fits_modifier, set_fits_modifier)
-    premis_modifier = property(get_premis_modifier, set_premis_modifier)
-    identifier = property(get_identifier, set_identifier)
+        pair_tree.write()

--- a/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemarchivewriter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemarchivewriter.py
@@ -271,12 +271,13 @@ class FileSystemArchiveWriter(ArchiveSerializationWriter):
     def _write_adminnotes(self, adminnotes_dir_path, admin_manifest):
         if self.get_struct().adminnote_list:
             for x in self.get_struct().adminnote_list:
+                dst_path = join(adminnotes_dir_path, x.item_name)
                 manifest_dict = {
                     'origin': x.item_name,
                     'acc_id': self.get_struct().identifier,
-                    'type': 'admin note'
+                    'type': 'admin note',
+                    'dst': dst_path
                 }
-                dst_path = join(adminnotes_dir_path, x.item_name)
                 dst_item = LDRPath(dst_path)
                 cr = LDRItemCopier(x, dst_item).copy()
                 if not cr['src_eqs_dst']:
@@ -289,12 +290,13 @@ class FileSystemArchiveWriter(ArchiveSerializationWriter):
     def _write_legalnotes(self, legalnotes_dir_path, admin_manifest):
         if self.get_struct().legalnote_list:
             for x in self.get_struct().legalnote_list:
+                dst_path = join(legalnotes_dir_path, x.item_name)
                 manifest_dict = {
                     'origin': x.item_name,
                     'acc_id': self.get_struct().identifier,
-                    'type': 'legal note'
+                    'type': 'legal note',
+                    'dst': dst_path
                 }
-                dst_path = join(legalnotes_dir_path, x.item_name)
                 dst_item = LDRPath(dst_path)
                 cr = LDRItemCopier(x, dst_item).copy()
                 if not cr['src_eqs_dst']:
@@ -307,12 +309,13 @@ class FileSystemArchiveWriter(ArchiveSerializationWriter):
     def _write_accessionrecords(self, accessionrecords_dir_path,
                                 admin_manifest):
         for x in self.get_struct().accessionrecord_list:
+            dst_path = join(accessionrecords_dir_path, x.item_name)
             manifest_dict = {
                 'origin': x.item_name,
                 'acc_id': self.get_struct().identifier,
-                'type': 'accession_record'
+                'type': 'accession_record',
+                'dst': dst_path
             }
-            dst_path = join(accessionrecords_dir_path, x.item_name)
             dst_item = LDRPath(dst_path)
             cr = LDRItemCopier(x, dst_item).copy()
             if not cr['src_eqs_dst']:
@@ -328,7 +331,8 @@ class FileSystemArchiveWriter(ArchiveSerializationWriter):
         manifest_dict = {
             'origin': None,
             'acc_id': self.get_struct().identifier,
-            'type': 'data_manifest'
+            'type': 'data_manifest',
+            'dst': 'data_manifest.json'
         }
         md5_hash_str = hash_ldritem(data_manifest_item, algo='md5')
         sha256_hash_str = hash_ldritem(data_manifest_item, algo='sha256')

--- a/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemarchivewriter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemarchivewriter.py
@@ -50,14 +50,13 @@ class FileSystemArchiveWriter(ArchiveSerializationWriter):
     Writes an archive structure to disk utilizing PairTrees as a series
     of directories and files.
     """
-    def __init__(self, anArchive, aRoot, live_premis_root, eq_detect="bytes"):
+    def __init__(self, anArchive, aRoot, eq_detect="bytes"):
         """
         spawn a writer
 
         """
         super().__init__(anArchive)
         self.lts_env_path = aRoot
-        self.live_premis_root = live_premis_root
         self.eq_detect = eq_detect
         log.debug("FileSystemArchiveWriter spawned: {}".format(str(self)))
 
@@ -183,19 +182,6 @@ class FileSystemArchiveWriter(ArchiveSerializationWriter):
                     manifest_dict['type'] = "PREMIS"
                     manifest_dict['md5'] = hash_ldritem(dst_item, algo='md5')
                     manifest_dict['sha256'] = hash_ldritem(dst_item, algo='sha256')
-                    live_premis_dir_path = join(
-                        self.live_premis_root,
-                        str(identifier_to_path(self.get_struct().identifier)),
-                        obj.encapsulation,
-                        "pairtree_root",
-                        str(identifier_to_path(obj.identifier)),
-                        obj.encapsulation
-                    )
-                    makedirs(live_premis_dir_path, exist_ok=True)
-                    live_premis_dst_item = LDRPath(join(live_premis_dir_path, "premis.xml"))
-                    cr = LDRItemCopier(dst_item, live_premis_dst_item).copy()
-                    if not cr['src_eqs_dst']:
-                        raise ValueError("Bad copy into the live premis dir!")
                 elif bytestream.intraobjectaddress == "fits.xml":
                     self._update_fits_in_place(join(ms_path, "fits.xml"),
                                                join(ms_path, "content.file"))

--- a/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemstagewriter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemstagewriter.py
@@ -153,7 +153,6 @@ class FileSystemStageWriter(StageSerializationWriter):
         try:
             if ms.get_presform_list():
                 for x in ms.get_presform_list():
-                    print(x.extension)
                     x.content.item_name = ms.content.item_name + \
                         ".presform" + \
                         x.extension

--- a/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemstagewriter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemstagewriter.py
@@ -153,6 +153,7 @@ class FileSystemStageWriter(StageSerializationWriter):
         try:
             if ms.get_presform_list():
                 for x in ms.get_presform_list():
+                    print(x.extension)
                     x.content.item_name = ms.content.item_name + \
                         ".presform" + \
                         x.extension

--- a/uchicagoldrtoolsuite/core/lib/identifier.py
+++ b/uchicagoldrtoolsuite/core/lib/identifier.py
@@ -22,6 +22,9 @@ class Identifier(IdentifierCategory):
         """
         self.category = category.upper()
 
+    def __str__(self):
+        return self.value
+
     def show(self):
         """returns a tuple containing the category and the identifier value
         of an instance of the identifier class


### PR DESCRIPTION
Closes #90 

Sets the originalName of presforms to their relative path in the staging directory

While the veracity of setting an originalName for presforms is debatable - the techmdcreator requires it for now, and without it no (sensible) path name is ever stored for presforms.

Merge #89 before merging this pull request
