### PR TITLE
Reader PREMIS Speedup, No PREMIS == No more checking for anything

### DIFF
--- a/uchicagoldrtoolsuite/bit_level/lib/readers/abc/materialsuitepackager.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/abc/materialsuitepackager.py
@@ -69,6 +69,15 @@ class MaterialSuitePackager(Packager, metaclass=ABCMeta):
                 ms.set_premis(val)
         except NotImplementedError:
             pass
+
+        # We do some expensive checking for things after this point so stop
+        # looking for anything if we don't find a PREMIS record. In the future
+        # finding the PREMIS record will be required because of the potential to
+        # need information out of the PREMIS record in order to locate the
+        # remaining components of the MaterialSuite
+        if not ms.get_premis():
+            return ms
+
         try:
             val = self.get_presform_list()
             if val:


### PR DESCRIPTION
This little fix speeds things up considerably, at the risk of not reading broken stages as coherently (the reader fails harder in environments which violate specifications).

I think this is a trade off I'm willing to make for the sake of increased productivity. Programming as defensively as this was originally isn't actually required in correct use cases.
