### PR TITLE
No techmd array

### DIFF
--- a/uchicagoldrtoolsuite/bit_level/lib/externalreaders/externalfilesystemmaterialsuitereader.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/externalreaders/externalfilesystemmaterialsuitereader.py
@@ -201,12 +201,6 @@ class ExternalFileSystemMaterialSuiteReader(MaterialSuiteSerializationReader):
             x.item_name = self.path
         return x
 
-    def get_techmd_list(self):
-        raise NotImplementedError()
-
-    def get_presform_list(self):
-        raise NotImplementedError()
-
     @log_aware(log)
     def get_bytes_path(self):
         return self._bytes_path

--- a/uchicagoldrtoolsuite/bit_level/lib/readers/abc/materialsuiteserializationreader.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/abc/materialsuiteserializationreader.py
@@ -24,7 +24,6 @@ class MaterialSuiteSerializationReader(SerializationReader, metaclass=ABCMeta):
     mandates:
         * .get_original()
         * .get_premis()
-        * .get_techmd_list()
 
     all of which should return LDRItem subclasses or iters of them, if list
     is specified in the method name.
@@ -54,10 +53,6 @@ class MaterialSuiteSerializationReader(SerializationReader, metaclass=ABCMeta):
 
     @abstractmethod
     def get_premis(self):
-        pass
-
-    @abstractmethod
-    def get_techmd_list(self):
         pass
 
     @log_aware(log)
@@ -90,15 +85,5 @@ class MaterialSuiteSerializationReader(SerializationReader, metaclass=ABCMeta):
         except NotImplementedError:
             log.debug("Reader does not implement get_content()")
 
-        log.debug("Packaing technical metadata")
-        try:
-            techmd_list = self.get_techmd_list()
-            if techmd_list:
-                log.debug("Technical metadata located")
-                self.struct.set_technicalmetadata_list(techmd_list)
-            else:
-                log.debug("No technical metadata located")
-        except NotImplementedError:
-            log.debug("Reader does not implement get_techmd_list()")
         log.info("Packaging complete")
         return self.struct

--- a/uchicagoldrtoolsuite/bit_level/lib/readers/filesystemmaterialsuitereader.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/readers/filesystemmaterialsuitereader.py
@@ -72,16 +72,3 @@ class FileSystemMaterialSuiteReader(MaterialSuiteSerializationReader):
         log.warn(
             "Premis not found for materialsuite @ {}".format(self.target_identifier)
         )
-
-    @log_aware(log)
-    def get_techmd_list(self):
-        log.debug("searching for technical metadata")
-        techmds = [LDRPath(x.path) for x in
-                   scandir(str(Path(self.path, 'TECHMD')))]
-        if not techmds:
-            log.debug(
-                "No techmd found for materialsuite @ {}".format(self.target_identifier)
-            )
-        else:
-            log.debug("Techmd located")
-            return techmds

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/archive.py
@@ -53,13 +53,6 @@ class Archive(AccessionContainer):
             if not isinstance(materialsuite.premis, LDRItem):
                 log.warn("MaterialSuite missing PREMIS metadata")
                 return False
-            # TODO: Decide if mandating technical metadata (when there's
-            # content) is a solid idea, is this an implementation specific
-            # detail?
-            if not len(materialsuite.technicalmetadata_list) > 0 and \
-                    isinstance(materialsuite.content, LDRItem):
-                log.warn("Content exists with no technical metadata")
-                return False
         except Exception:
             log.critical("Problem in MaterialSuite validation")
             return False

--- a/uchicagoldrtoolsuite/bit_level/lib/structures/materialsuite.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/structures/materialsuite.py
@@ -31,7 +31,6 @@ class MaterialSuite(object):
         log_init_attempt(self, log, locals())
         self._content = None
         self._premis = None
-        self._technicalmetadata = []
         self._identifier = None
         self.identifier = identifier
         log_init_success(self, log)
@@ -43,10 +42,6 @@ class MaterialSuite(object):
             'content': str(self.get_content()),
             'premis': str(self.get_premis())
         }
-        if self.technicalmetadata_list:
-            attr_dict['technicalmetadata_list'] = [str(x) for x in self.technicalmetadata_list]
-        else:
-            attr_dict['technicalmetadata_list'] = None
         return "<MaterialSuite {}>".format(dumps(attr_dict, sort_keys=True))
 
     @log_aware(log)
@@ -92,43 +87,6 @@ class MaterialSuite(object):
         self._premis = None
 
     @log_aware(log)
-    def get_technicalmetadata_list(self):
-        return self._technicalmetadata
-
-    @log_aware(log)
-    def set_technicalmetadata_list(self, technicalmetadata_list):
-        self.del_technicalmetadata_list()
-        self._technicalmetadata = []
-        for x in technicalmetadata_list:
-            self.add_technicalmetadata(x)
-
-    @log_aware(log)
-    def del_technicalmetadata_list(self):
-        while self.get_technicalmetadata_list():
-            self.pop_technicalmetadata()
-
-    @log_aware(log)
-    def add_technicalmetadata(self, technicalmetadata, index=None):
-        if self.get_technicalmetadata_list() is None:
-            self._technicalmetadata = []
-        if index is None:
-            index = len(self.get_technicalmetadata_list())
-        self.get_technicalmetadata_list().insert(index, technicalmetadata)
-        log.debug("Added technicalmetadata({}) to {}".format(str(technicalmetadata), str(self)))
-
-    @log_aware(log)
-    def get_technicalmetadata(self, index):
-        return self.get_technicalmetadata_list()[index]
-
-    @log_aware(log)
-    def pop_technicalmetadata(self, index=None):
-        if index is None:
-            x = self.get_technicalmetadata_list().pop()
-        else:
-            x = self.get_technicalmetadata_list.pop(index)
-        log.debug("Popped technicalmetadata({}) from {}".format(str(x), str(self)))
-
-    @log_aware(log)
     def validate(self):
         """
         Determines if a MaterialSuite is well formed
@@ -136,13 +94,6 @@ class MaterialSuite(object):
         if self.get_premis() is not None:
             if not isinstance(self.get_premis(), LDRItem):
                 return False
-        if self.get_content() is not None and \
-                not len(self.get_technicalmetadata_list()) > 0:
-            return False
-        if len(self.get_technicalmetadata_list()) > 0:
-            for x in self.get_technicalmetadata_list():
-                if not isinstance(x, LDRItem):
-                    return False
         return super().validate()
 
     identifier = property(
@@ -161,10 +112,4 @@ class MaterialSuite(object):
         get_premis,
         set_premis,
         del_premis
-    )
-
-    technicalmetadata_list = property(
-        get_technicalmetadata_list,
-        set_technicalmetadata_list,
-        del_technicalmetadata_list
     )

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/abc/technicalmetadatacreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/abc/technicalmetadatacreator.py
@@ -88,7 +88,7 @@ class TechnicalMetadataCreator(metaclass=ABCMeta):
 
     @log_aware(log)
     def handle_premis(self, cmd_output, material_suite, techmdcreator_name,
-                      success):
+                      success, record_entry_name, record_path):
         """
         Handles altering the MaterialSuites PREMIS after processing.
         Either records successful techmd creation, or failure.
@@ -115,6 +115,16 @@ class TechnicalMetadataCreator(metaclass=ABCMeta):
         orig_premis.get_object_list()[0].add_linkingEventIdentifier(
             self._build_linkingEventIdentifier(event)
         )
+        if success:
+            objectCharacteristicsExtension = ObjectCharacteristicsExtension()
+            with open(record_path, 'r') as f:
+                record_str = f.read()
+            objectCharacteristicsExtension.set_field(record_entry_name,
+                                                     record_str)
+            orig_premis.get_object_list()[0].get_objectCharacteristics()[0].\
+                add_objectCharacteristicsExtension(
+                    objectCharacteristicsExtension
+                )
 
         updated_premis_path = join(self.working_dir, str(uuid1()))
         orig_premis.write_to_file(updated_premis_path)

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/apifitscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/apifitscreator.py
@@ -134,21 +134,20 @@ class APIFITsCreator(TechnicalMetadataCreator):
         except Exception as e:
             log.warn("FITS creation failed: {}".format(str(e)))
         log.debug("Updating PREMIS")
+
         if isfile(fits_file_path):
+            success = True
+            log.debug("FITS successfully created")
+            # Chop this bit out
             self.get_source_materialsuite().add_technicalmetadata(
                 LDRPath(fits_file_path)
             )
-            self.handle_premis(
-                "Successfully retrieved FITS from API",
-                self.get_source_materialsuite(),
-                "FITs", True
-            )
         else:
-            self.handle_premis(
-                "Failed Retrieving FITS from API ({})".format(str(exc)),
-                self.get_source_materialsuite(),
-                "FITs", False
+            success = False
+            log.warn("FITS creation failed on {}".format(
+                self.get_source_materialsuite().identifier)
             )
-
+        self.handle_premis(cmd_data, self.get_source_materialsuite(),
+                            "FITs", success, "fitsRecord", fits_file_path)
         log.debug("Deleting temporary holder file")
         original_holder.delete(final=True)

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/apifitscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/apifitscreator.py
@@ -138,10 +138,6 @@ class APIFITsCreator(TechnicalMetadataCreator):
         if isfile(fits_file_path):
             success = True
             log.debug("FITS successfully created")
-            # Chop this bit out
-            self.get_source_materialsuite().add_technicalmetadata(
-                LDRPath(fits_file_path)
-            )
         else:
             success = False
             log.warn("FITS creation failed on {}".format(

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/fitscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/fitscreator.py
@@ -124,10 +124,6 @@ class FITsCreator(TechnicalMetadataCreator):
         if isfile(fits_file_path):
             success = True
             log.debug("FITS successfully created")
-            # Chop this bit out
-            self.get_source_materialsuite().add_technicalmetadata(
-                LDRPath(fits_file_path)
-            )
         else:
             success = False
             log.warn("FITS creation failed on {}".format(

--- a/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/fitscreator.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/techmdcreators/fitscreator.py
@@ -4,6 +4,9 @@ from uuid import uuid4
 from json import dumps
 from logging import getLogger
 
+from pypremis.lib import PremisRecord
+from pypremis.nodes import ObjectCharacteristicsExtension
+
 from uchicagoldrtoolsuite import log_aware
 from uchicagoldrtoolsuite.core.lib.bash_cmd import BashCommand
 from uchicagoldrtoolsuite.core.lib.convenience import log_init_attempt, \
@@ -119,18 +122,18 @@ class FITsCreator(TechnicalMetadataCreator):
         cmd_data = cmd.get_data()
 
         if isfile(fits_file_path):
+            success = True
             log.debug("FITS successfully created")
+            # Chop this bit out
             self.get_source_materialsuite().add_technicalmetadata(
                 LDRPath(fits_file_path)
             )
-            self.handle_premis(cmd_data, self.get_source_materialsuite(),
-                               "FITs", True)
         else:
+            success = False
             log.warn("FITS creation failed on {}".format(
                 self.get_source_materialsuite().identifier)
             )
-            self.handle_premis(cmd_data, self.get_source_materialsuite(),
-                               "FITs", False)
-
+        self.handle_premis(cmd_data, self.get_source_materialsuite(),
+                            "FITs", success, "fitsRecord", fits_file_path)
         log.debug("Cleaning up temporary file instantiation")
         original_holder.delete(final=True)

--- a/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemmaterialsuitewriter.py
+++ b/uchicagoldrtoolsuite/bit_level/lib/writers/filesystemmaterialsuitewriter.py
@@ -11,7 +11,6 @@ from .abc.materialsuiteserializationwriter import \
     MaterialSuiteSerializationWriter
 from ..ldritems.ldrpath import LDRPath
 from ..ldritems.ldritemcopier import LDRItemCopier
-from ..ldritems.ldritemoperations import hash_ldritem
 
 
 __author__ = "Brian Balsamo"
@@ -80,7 +79,7 @@ class FileSystemMaterialSuiteWriter(MaterialSuiteSerializationWriter):
             raise RuntimeError("MaterialSuite writer can't clobber a file " +
                                "where a directory should be! " +
                                "{}".format(str(self.materialsuite_root)))
-        makedirs(str(Path(self.materialsuite_root, 'TECHMD')))
+        makedirs(str(Path(self.materialsuite_root)))
 
     @log_aware(log)
     def write(self):
@@ -103,26 +102,9 @@ class FileSystemMaterialSuiteWriter(MaterialSuiteSerializationWriter):
                                            target_content_item,
                                            clobber=self.clobber)
 
-        log.debug("Computing techmd file names")
-        techmd_copiers = []
-        for x in self.struct.technicalmetadata_list:
-            # Use a quick checksum as the file name, this should prevent
-            # un-needed writing so long as the records don't change in between
-            # reading and writing a stage where the TECHMD already exists.
-            # It also keeps the names equivalent if a stage is moved
-            # from one root to another.
-            # So long as the file sizes stay small the overhead of computing
-            # a quick checksum like adler should be negligible.
-            h = hash_ldritem(x, algo="adler32")
-            target_techmd_path = Path(self.materialsuite_root,
-                                      'TECHMD', h)
-            target_techmd_item = LDRPath(str(target_techmd_path))
-            techmd_copiers.append(LDRItemCopier(x, target_techmd_item,
-                                                clobber=self.clobber))
-
         log.debug("Copying MaterialSuite bytestreams to disk")
         content_cr = None
-        for x in [premis_copier, content_copier] + techmd_copiers:
+        for x in [premis_copier, content_copier]:
             if x is not None:
                 cr = x.copy()
                 if not cr['src_eqs_dst']:


### PR DESCRIPTION
Removed the technical metadata array from the MaterialSuite structure. Technical metadata is now written into the PREMIS instead, which better handles the unbounded cardinality of the technical metadata records.