### PR TITLE
Logging encoding

### DIFF
--- a/uchicagoldrtoolsuite/__init__.py
+++ b/uchicagoldrtoolsuite/__init__.py
@@ -133,7 +133,8 @@ def activate_master_log_file(logdir=None, max_log_size=1000000000,
         makedirs(dirname(mlog_filepath), exist_ok=True)
     h1 = MultiprocessRotatingFileHandler(mlog_filepath,
                                          maxBytes=int(max_log_size/5),
-                                         backupCount=num_backups)
+                                         backupCount=num_backups,
+                                         encoding="UTF-8")
     h1.setLevel(verbosity)
     h1.setFormatter(_f)
     root_log.addHandler(h1)

--- a/uchicagoldrtoolsuite/__init__.py
+++ b/uchicagoldrtoolsuite/__init__.py
@@ -167,7 +167,7 @@ def activate_job_log_file(job_logdir=None, verbosity="DEBUG"):
     jlog_filepath = join(job_logdir, iso8601_dt() + "_" + uuid4().hex)
     if exists(jlog_filepath):
         raise ValueError('The randomly generated job log file already exists!')
-    h2 = FileHandler(jlog_filepath)
+    h2 = FileHandler(jlog_filepath, encoding="UTF-8")
     h2.setLevel(verbosity)
     h2.setFormatter(_f)
     root_log.addHandler(h2)


### PR DESCRIPTION
Manually specified logging encoding to be utf-8 to prevent python logging from throwing exceptions when crazily-named things are kicked into the logs.